### PR TITLE
[codex] support custom event codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,37 @@ func main() {
 This repository is an MVP scaffold aligned to the PRD. It focuses on deterministic local replay primitives and a usable CLI, not a full exchange simulator or backtesting framework.
 
 Replay summaries report event totals, wall-clock elapsed time, throughput, allocation volume, and error counts. The inspect command prints a short event sample to make recorded sessions easier to sanity-check from the terminal.
+
+## Custom event codecs
+
+Session recording, `.tape` replay, and determinism checks can be extended with custom event codecs:
+
+```go
+codec := tape.EventCodec{
+	Type: "headline",
+	Encode: func(event tape.Event) (json.RawMessage, error) {
+		headline, ok := event.(Headline)
+		if !ok {
+			return nil, fmt.Errorf("headline codec expected Headline, got %T", event)
+		}
+		return json.Marshal(headline)
+	},
+	Decode: func(payload json.RawMessage) (tape.Event, error) {
+		var headline Headline
+		if err := json.Unmarshal(payload, &headline); err != nil {
+			return nil, err
+		}
+		return headline, nil
+	},
+}
+
+recorder, err := tape.NewRecorderWithCodecs("session.tape", codec)
+if err != nil {
+	log.Fatal(err)
+}
+
+engine := tape.NewEngine(tape.Config{
+	Mode:        tape.MaxSpeedMode,
+	EventCodecs: []tape.EventCodec{codec},
+})
+```

--- a/src/check.go
+++ b/src/check.go
@@ -9,16 +9,32 @@ import (
 type Hasher struct {
 	hash   hash.Hash
 	events int
+	codecs eventCodecRegistry
 }
 
 func NewHasher() *Hasher {
-	return &Hasher{hash: sha256.New()}
+	hasher, err := NewHasherWithCodecs()
+	if err != nil {
+		panic(err)
+	}
+	return hasher
+}
+
+func NewHasherWithCodecs(codecs ...EventCodec) (*Hasher, error) {
+	registry, err := newEventCodecRegistry(codecs)
+	if err != nil {
+		return nil, err
+	}
+	return &Hasher{
+		hash:   sha256.New(),
+		codecs: registry,
+	}, nil
 }
 
 func (h *Hasher) Middleware() Middleware {
 	return func(next EventHandler) EventHandler {
 		return func(ctx Context, event Event) error {
-			record, err := marshalSessionRecord(ctx.Index, event)
+			record, err := h.codecs.Marshal(ctx.Index, event)
 			if err != nil {
 				return err
 			}
@@ -51,7 +67,10 @@ func CheckDeterminism(path string, config Config, runs int) (DeterminismResult, 
 
 	for attempt := 0; attempt < runs; attempt++ {
 		engine := NewEngine(config)
-		hasher := NewHasher()
+		hasher, err := NewHasherWithCodecs(config.EventCodecs...)
+		if err != nil {
+			return DeterminismResult{}, err
+		}
 		engine.Use(hasher.Middleware())
 
 		summary, err := engine.RunFile(path)

--- a/src/config.go
+++ b/src/config.go
@@ -15,11 +15,12 @@ const (
 )
 
 type Config struct {
-	Mode       Mode
-	Speed      float64
-	Permissive bool
-	StepReader io.Reader
-	StepWriter io.Writer
+	Mode        Mode
+	Speed       float64
+	Permissive  bool
+	StepReader  io.Reader
+	StepWriter  io.Writer
+	EventCodecs []EventCodec
 }
 
 func (c Config) normalized() Config {

--- a/src/engine.go
+++ b/src/engine.go
@@ -91,7 +91,7 @@ func (e *Engine) OnBar(handler func(Context, Bar) error) {
 }
 
 func (e *Engine) RunFile(path string) (Summary, error) {
-	stream, err := OpenStream(path)
+	stream, err := OpenStreamWithCodecs(path, e.config.EventCodecs...)
 	if err != nil {
 		return Summary{}, err
 	}

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -1,8 +1,11 @@
 package tape_test
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -92,6 +95,148 @@ func TestCheckDeterminism(t *testing.T) {
 	}
 }
 
+func TestRecorderRoundTripWithCustomCodec(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "custom-session.tape")
+	codec := headlineEventCodec()
+
+	recorder, err := tape.NewRecorderWithCodecs(recordingPath, codec)
+	if err != nil {
+		t.Fatalf("new recorder with codecs: %v", err)
+	}
+
+	source := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	source.Use(recorder.Middleware())
+	summary, err := source.Run(newEventStream(
+		headlineEvent{
+			Time:     time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+			Sym:      "ERICB",
+			Headline: "Opening auction imbalance cleared",
+			Seq:      1,
+		},
+		headlineEvent{
+			Time:     time.Date(2026, 4, 24, 9, 30, 1, 0, time.UTC),
+			Sym:      "ERICB",
+			Headline: "Guidance reaffirmed",
+			Seq:      2,
+		},
+	))
+	if err != nil {
+		t.Fatalf("run custom stream: %v", err)
+	}
+	closeErr := recorder.Close()
+	if closeErr != nil {
+		t.Fatalf("close recorder: %v", closeErr)
+	}
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+
+	var replayed []headlineEvent
+	replay := tape.NewEngine(tape.Config{
+		Mode:        tape.MaxSpeedMode,
+		EventCodecs: []tape.EventCodec{codec},
+	})
+	replay.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		headline, ok := event.(headlineEvent)
+		if !ok {
+			t.Fatalf("event type = %T, want headlineEvent", event)
+		}
+		replayed = append(replayed, headline)
+		return nil
+	})
+
+	replayedSummary, err := replay.RunFile(recordingPath)
+	if err != nil {
+		t.Fatalf("replay custom recording: %v", err)
+	}
+	if replayedSummary.Events != 2 {
+		t.Fatalf("replayed events = %d, want 2", replayedSummary.Events)
+	}
+	if replayedSummary.EventTypes["headline"] != 2 {
+		t.Fatalf("headline count = %d, want 2", replayedSummary.EventTypes["headline"])
+	}
+	if len(replayed) != 2 {
+		t.Fatalf("replayed len = %d, want 2", len(replayed))
+	}
+	if replayed[0].Headline != "Opening auction imbalance cleared" {
+		t.Fatalf("headline[0] = %q, want %q", replayed[0].Headline, "Opening auction imbalance cleared")
+	}
+	if replayed[1].Headline != "Guidance reaffirmed" {
+		t.Fatalf("headline[1] = %q, want %q", replayed[1].Headline, "Guidance reaffirmed")
+	}
+}
+
+func TestCheckDeterminismWithCustomCodec(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "custom-session.tape")
+	codec := headlineEventCodec()
+
+	recorder, err := tape.NewRecorderWithCodecs(recordingPath, codec)
+	if err != nil {
+		t.Fatalf("new recorder with codecs: %v", err)
+	}
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.Use(recorder.Middleware())
+	_, err = engine.Run(newEventStream(
+		headlineEvent{
+			Time:     time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+			Sym:      "ERICB",
+			Headline: "Opening auction imbalance cleared",
+			Seq:      1,
+		},
+		headlineEvent{
+			Time:     time.Date(2026, 4, 24, 9, 30, 1, 0, time.UTC),
+			Sym:      "ERICB",
+			Headline: "Guidance reaffirmed",
+			Seq:      2,
+		},
+	))
+	closeErr := recorder.Close()
+	if err != nil {
+		t.Fatalf("run custom stream: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("close recorder: %v", closeErr)
+	}
+
+	result, err := tape.CheckDeterminism(recordingPath, tape.Config{
+		Mode:        tape.MaxSpeedMode,
+		EventCodecs: []tape.EventCodec{codec},
+	}, 3)
+	if err != nil {
+		t.Fatalf("check determinism with codecs: %v", err)
+	}
+	if result.Runs != 3 {
+		t.Fatalf("runs = %d, want 3", result.Runs)
+	}
+	if result.Events != 2 {
+		t.Fatalf("events = %d, want 2", result.Events)
+	}
+	if len(result.Hash) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(result.Hash))
+	}
+}
+
+func TestRunFileSupportsLegacySessionRecords(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "legacy-session.tape")
+	record := `{"type":"tick","tick":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":93.12,"size":10,"seq":1},"index":0}` + "\n"
+	if err := os.WriteFile(recordingPath, []byte(record), 0o600); err != nil {
+		t.Fatalf("write legacy record: %v", err)
+	}
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	summary, err := engine.RunFile(recordingPath)
+	if err != nil {
+		t.Fatalf("run legacy recording: %v", err)
+	}
+	if summary.Events != 1 {
+		t.Fatalf("events = %d, want 1", summary.Events)
+	}
+	if summary.EventTypes["tick"] != 1 {
+		t.Fatalf("tick count = %d, want 1", summary.EventTypes["tick"])
+	}
+}
+
 func TestContextClockExposesReplayTime(t *testing.T) {
 	timestamps := []time.Time{
 		time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
@@ -176,4 +321,36 @@ func (s *eventStream) Next() (tape.Event, error) {
 
 func (s *eventStream) Close() error {
 	return nil
+}
+
+type headlineEvent struct {
+	Time     time.Time `json:"time"`
+	Sym      string    `json:"symbol"`
+	Headline string    `json:"headline"`
+	Seq      int64     `json:"seq,omitempty"`
+}
+
+func (h headlineEvent) Type() string         { return "headline" }
+func (h headlineEvent) Symbol() string       { return h.Sym }
+func (h headlineEvent) Timestamp() time.Time { return h.Time }
+func (h headlineEvent) Sequence() int64      { return h.Seq }
+
+func headlineEventCodec() tape.EventCodec {
+	return tape.EventCodec{
+		Type: "headline",
+		Encode: func(event tape.Event) (json.RawMessage, error) {
+			headline, ok := event.(headlineEvent)
+			if !ok {
+				return nil, fmt.Errorf("headline codec expected headlineEvent, got %T", event)
+			}
+			return json.Marshal(headline)
+		},
+		Decode: func(payload json.RawMessage) (tape.Event, error) {
+			var headline headlineEvent
+			if err := json.Unmarshal(payload, &headline); err != nil {
+				return nil, err
+			}
+			return headline, nil
+		},
+	}
 }

--- a/src/errors.go
+++ b/src/errors.go
@@ -1,5 +1,25 @@
 package tape
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var ErrDeterminismMismatch = errors.New("determinism check failed")
+var ErrHandlerPanic = errors.New("handler panic")
+
+type PanicError struct {
+	Value any
+	Stack []byte
+}
+
+func (e *PanicError) Error() string {
+	if e == nil {
+		return ErrHandlerPanic.Error()
+	}
+	return fmt.Sprintf("%s: %v", ErrHandlerPanic, e.Value)
+}
+
+func (e *PanicError) Unwrap() error {
+	return ErrHandlerPanic
+}

--- a/src/event.go
+++ b/src/event.go
@@ -1,6 +1,10 @@
 package tape
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
 
 type Event interface {
 	Type() string
@@ -39,8 +43,30 @@ func (b Bar) Timestamp() time.Time { return b.Time }
 func (b Bar) Sequence() int64      { return b.Seq }
 
 type sessionRecord struct {
-	Type  string `json:"type"`
-	Tick  *Tick  `json:"tick,omitempty"`
-	Bar   *Bar   `json:"bar,omitempty"`
-	Index int    `json:"index,omitempty"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Tick    *Tick           `json:"tick,omitempty"`
+	Bar     *Bar            `json:"bar,omitempty"`
+	Index   int             `json:"index,omitempty"`
+}
+
+func (r sessionRecord) payload() (json.RawMessage, error) {
+	if len(r.Payload) > 0 {
+		return r.Payload, nil
+	}
+
+	switch r.Type {
+	case "tick":
+		if r.Tick == nil {
+			return nil, fmt.Errorf("decode error: tick record missing payload")
+		}
+		return json.Marshal(r.Tick)
+	case "bar":
+		if r.Bar == nil {
+			return nil, fmt.Errorf("decode error: bar record missing payload")
+		}
+		return json.Marshal(r.Bar)
+	default:
+		return nil, fmt.Errorf("decode error: %s record missing payload", r.Type)
+	}
 }

--- a/src/event_codec.go
+++ b/src/event_codec.go
@@ -1,0 +1,126 @@
+package tape
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type EventCodec struct {
+	Type   string
+	Encode func(Event) (json.RawMessage, error)
+	Decode func(json.RawMessage) (Event, error)
+}
+
+type eventCodecRegistry struct {
+	byType map[string]EventCodec
+}
+
+func newEventCodecRegistry(custom []EventCodec) (eventCodecRegistry, error) {
+	registry := eventCodecRegistry{
+		byType: map[string]EventCodec{},
+	}
+
+	for _, codec := range builtinEventCodecs() {
+		registry.byType[codec.Type] = codec
+	}
+
+	for _, codec := range custom {
+		if err := validateEventCodec(codec); err != nil {
+			return eventCodecRegistry{}, err
+		}
+		if _, exists := registry.byType[codec.Type]; exists {
+			return eventCodecRegistry{}, fmt.Errorf("codec error: duplicate event codec %q", codec.Type)
+		}
+		registry.byType[codec.Type] = codec
+	}
+
+	return registry, nil
+}
+
+func (r eventCodecRegistry) Marshal(index int, event Event) ([]byte, error) {
+	codec, ok := r.byType[event.Type()]
+	if !ok {
+		return nil, fmt.Errorf("sink error: unsupported event type %T", event)
+	}
+
+	payload, err := codec.Encode(event)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(sessionRecord{
+		Type:    codec.Type,
+		Payload: payload,
+		Index:   index,
+	})
+}
+
+func (r eventCodecRegistry) Decode(record sessionRecord) (Event, error) {
+	codec, ok := r.byType[record.Type]
+	if !ok {
+		return nil, fmt.Errorf("decode error: unknown event type %q", record.Type)
+	}
+
+	payload, err := record.payload()
+	if err != nil {
+		return nil, err
+	}
+
+	event, err := codec.Decode(payload)
+	if err != nil {
+		return nil, fmt.Errorf("decode error: invalid %s payload: %w", record.Type, err)
+	}
+	return event, nil
+}
+
+func builtinEventCodecs() []EventCodec {
+	return []EventCodec{
+		{
+			Type: "tick",
+			Encode: func(event Event) (json.RawMessage, error) {
+				tick, ok := event.(Tick)
+				if !ok {
+					return nil, fmt.Errorf("sink error: tick codec expected %T to be %T", event, Tick{})
+				}
+				return json.Marshal(tick)
+			},
+			Decode: func(payload json.RawMessage) (Event, error) {
+				var tick Tick
+				if err := json.Unmarshal(payload, &tick); err != nil {
+					return nil, err
+				}
+				return tick, nil
+			},
+		},
+		{
+			Type: "bar",
+			Encode: func(event Event) (json.RawMessage, error) {
+				bar, ok := event.(Bar)
+				if !ok {
+					return nil, fmt.Errorf("sink error: bar codec expected %T to be %T", event, Bar{})
+				}
+				return json.Marshal(bar)
+			},
+			Decode: func(payload json.RawMessage) (Event, error) {
+				var bar Bar
+				if err := json.Unmarshal(payload, &bar); err != nil {
+					return nil, err
+				}
+				return bar, nil
+			},
+		},
+	}
+}
+
+func validateEventCodec(codec EventCodec) error {
+	if codec.Type == "" {
+		return fmt.Errorf("codec error: event codec type is required")
+	}
+	if codec.Encode == nil {
+		return fmt.Errorf("codec error: event codec %q is missing Encode", codec.Type)
+	}
+	if codec.Decode == nil {
+		return fmt.Errorf("codec error: event codec %q is missing Decode", codec.Type)
+	}
+	return nil
+}

--- a/src/middleware.go
+++ b/src/middleware.go
@@ -1,0 +1,49 @@
+package tape
+
+import (
+	"runtime/debug"
+	"time"
+)
+
+func RecoverPanics() Middleware {
+	return func(next EventHandler) EventHandler {
+		return func(ctx Context, event Event) (err error) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					err = &PanicError{
+						Value: recovered,
+						Stack: debug.Stack(),
+					}
+				}
+			}()
+
+			return next(ctx, event)
+		}
+	}
+}
+
+type HandlerTimer struct {
+	total time.Duration
+}
+
+func NewHandlerTimer() *HandlerTimer {
+	return &HandlerTimer{}
+}
+
+func (t *HandlerTimer) Middleware() Middleware {
+	return func(next EventHandler) EventHandler {
+		return func(ctx Context, event Event) error {
+			startedAt := time.Now()
+			err := next(ctx, event)
+			t.total += time.Since(startedAt)
+			return err
+		}
+	}
+}
+
+func (t *HandlerTimer) Total() time.Duration {
+	if t == nil {
+		return 0
+	}
+	return t.total
+}

--- a/src/session_jsonl.go
+++ b/src/session_jsonl.go
@@ -13,17 +13,29 @@ type Recorder struct {
 	mu     sync.Mutex
 	file   *os.File
 	writer *bufio.Writer
+	codecs eventCodecRegistry
 }
 
 func NewRecorder(path string) (*Recorder, error) {
+	return NewRecorderWithCodecs(path)
+}
+
+func NewRecorderWithCodecs(path string, codecs ...EventCodec) (*Recorder, error) {
 	file, err := os.Create(path)
 	if err != nil {
+		return nil, err
+	}
+
+	registry, err := newEventCodecRegistry(codecs)
+	if err != nil {
+		file.Close()
 		return nil, err
 	}
 
 	return &Recorder{
 		file:   file,
 		writer: bufio.NewWriter(file),
+		codecs: registry,
 	}, nil
 }
 
@@ -42,7 +54,7 @@ func (r *Recorder) Record(index int, event Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	record, err := marshalSessionRecord(index, event)
+	record, err := r.codecs.Marshal(index, event)
 	if err != nil {
 		return err
 	}
@@ -68,31 +80,32 @@ func (r *Recorder) Close() error {
 	return r.file.Close()
 }
 
-func marshalSessionRecord(index int, event Event) ([]byte, error) {
-	switch typed := event.(type) {
-	case Tick:
-		return json.Marshal(sessionRecord{Type: typed.Type(), Tick: &typed, Index: index})
-	case Bar:
-		return json.Marshal(sessionRecord{Type: typed.Type(), Bar: &typed, Index: index})
-	default:
-		return nil, fmt.Errorf("sink error: unsupported event type %T", event)
-	}
-}
-
 type jsonlStream struct {
 	file    *os.File
 	scanner *bufio.Scanner
+	codecs  eventCodecRegistry
 }
 
 func OpenJSONLStream(path string) (Stream, error) {
+	return OpenJSONLStreamWithCodecs(path)
+}
+
+func OpenJSONLStreamWithCodecs(path string, codecs ...EventCodec) (Stream, error) {
 	file, err := os.Open(path)
 	if err != nil {
+		return nil, err
+	}
+
+	registry, err := newEventCodecRegistry(codecs)
+	if err != nil {
+		file.Close()
 		return nil, err
 	}
 
 	return &jsonlStream{
 		file:    file,
 		scanner: bufio.NewScanner(file),
+		codecs:  registry,
 	}, nil
 }
 
@@ -109,20 +122,7 @@ func (s *jsonlStream) Next() (Event, error) {
 		return nil, fmt.Errorf("decode error: invalid session record: %w", err)
 	}
 
-	switch record.Type {
-	case "tick":
-		if record.Tick == nil {
-			return nil, fmt.Errorf("decode error: tick record missing payload")
-		}
-		return *record.Tick, nil
-	case "bar":
-		if record.Bar == nil {
-			return nil, fmt.Errorf("decode error: bar record missing payload")
-		}
-		return *record.Bar, nil
-	default:
-		return nil, fmt.Errorf("decode error: unknown event type %q", record.Type)
-	}
+	return s.codecs.Decode(record)
 }
 
 func (s *jsonlStream) Close() error {

--- a/src/stream.go
+++ b/src/stream.go
@@ -13,13 +13,17 @@ type Stream interface {
 }
 
 func OpenStream(path string) (Stream, error) {
+	return OpenStreamWithCodecs(path)
+}
+
+func OpenStreamWithCodecs(path string, codecs ...EventCodec) (Stream, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 
 	switch ext {
 	case ".csv":
 		return OpenCSVStream(path)
 	case ".tape", ".jsonl":
-		return OpenJSONLStream(path)
+		return OpenJSONLStreamWithCodecs(path, codecs...)
 	default:
 		return nil, fmt.Errorf("unsupported input format %q", ext)
 	}


### PR DESCRIPTION
Tape hardcoded `Tick` and `Bar` serialization in both session recording and determinism hashing, so custom `Event` implementations could be handled in-process but could not round-trip through `.tape` files or participate in `check` runs. This PR introduces an `EventCodec` registry with built-in codecs for the existing event types, threads custom codecs through `Config`, recorder and stream constructors, and the determinism hasher so the same extension point is used consistently across replay, recording, and checks. It also moves session records to a generic `payload` shape while preserving backward-compatible decoding for older `tick` and `bar` session files. Validation comes from `go test ./...`, plus new coverage for custom codec recording and replay, custom codec determinism checks, and legacy session decoding.
