### PR TITLE
[codex] Add replay filters and handler metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ go install github.com/erik-kroon/tape/cmd/tape@latest
 tape replay testdata/bars_5_rows.csv --speed 100x --metrics
 ```
 
+## Replay a filtered subset
+
+```bash
+tape replay testdata/bars_5_rows.csv --symbol ERICB --event-type bar --from 2026-04-24T09:31:00Z --to 2026-04-24T09:33:00Z
+```
+
 ## Step through a session
 
 ```bash
@@ -91,6 +97,8 @@ func main() {
 This repository is an MVP scaffold aligned to the PRD. It focuses on deterministic local replay primitives and a usable CLI, not a full exchange simulator or backtesting framework.
 
 Replay summaries report event totals, wall-clock elapsed time, throughput, allocation volume, and error counts. The inspect command prints a short event sample to make recorded sessions easier to sanity-check from the terminal.
+
+`replay`, `inspect`, and `check` all support the same inclusive filters: `--symbol` for one or more comma-separated symbols, `--event-type` for one or more comma-separated event types, and `--from` / `--to` for RFC3339 time bounds.
 
 ## Custom event codecs
 

--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -52,18 +52,31 @@ func runReplay(args []string) error {
 	metrics := flags.Bool("metrics", true, "print replay summary")
 	recordPath := flags.String("record", "", "record events to a .tape file")
 	permissive := flags.Bool("permissive", false, "continue through out-of-order timestamps")
+	symbols := flags.String("symbol", "", "comma-separated symbol filters")
+	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
+	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
+	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
-		"--speed":  true,
-		"--record": true,
+		"--speed":      true,
+		"--record":     true,
+		"--symbol":     true,
+		"--event-type": true,
+		"--from":       true,
+		"--to":         true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape replay <path> [--speed max|realtime|100x] [--step]")
+		return errors.New("usage: tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
 	}
 
-	config, err := configFromFlags(*speed, *step, *permissive)
+	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
+	if err != nil {
+		return err
+	}
+
+	config, err := configFromFlags(*speed, *step, *permissive, filter)
 	if err != nil {
 		return err
 	}
@@ -100,23 +113,41 @@ func runInspect(args []string) error {
 	flags := flag.NewFlagSet("inspect", flag.ContinueOnError)
 	sample := flags.Int("sample", 3, "number of sample events to print")
 	permissive := flags.Bool("permissive", false, "continue through out-of-order timestamps")
+	symbols := flags.String("symbol", "", "comma-separated symbol filters")
+	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
+	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
+	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
-		"--sample": true,
+		"--sample":     true,
+		"--symbol":     true,
+		"--event-type": true,
+		"--from":       true,
+		"--to":         true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape inspect <path> [--sample N]")
+		return errors.New("usage: tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+	}
+
+	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
+	if err != nil {
+		return err
 	}
 
 	path := flags.Arg(0)
-	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode, Permissive: *permissive})
+	config := tape.Config{
+		Mode:       tape.MaxSpeedMode,
+		Permissive: *permissive,
+		Filter:     filter,
+	}
+	engine := tape.NewEngine(config)
 	summary, err := engine.RunFile(path)
 	if err != nil {
 		return err
 	}
-	samples, err := sampleEvents(path, *sample)
+	samples, err := sampleEvents(path, *sample, filter)
 	if err != nil {
 		return err
 	}
@@ -166,19 +197,33 @@ func runCheck(args []string) error {
 	flags := flag.NewFlagSet("check", flag.ContinueOnError)
 	runs := flags.Int("runs", 5, "number of replay runs")
 	permissive := flags.Bool("permissive", false, "continue through out-of-order timestamps")
+	symbols := flags.String("symbol", "", "comma-separated symbol filters")
+	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
+	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
+	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
-		"--runs": true,
+		"--runs":       true,
+		"--symbol":     true,
+		"--event-type": true,
+		"--from":       true,
+		"--to":         true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape check <path> [--runs N]")
+		return errors.New("usage: tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+	}
+
+	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
+	if err != nil {
+		return err
 	}
 
 	result, err := tape.CheckDeterminism(flags.Arg(0), tape.Config{
 		Mode:       tape.MaxSpeedMode,
 		Permissive: *permissive,
+		Filter:     filter,
 	}, *runs)
 	if err != nil {
 		return err
@@ -192,17 +237,17 @@ func runCheck(args []string) error {
 	return nil
 }
 
-func configFromFlags(speed string, step bool, permissive bool) (tape.Config, error) {
+func configFromFlags(speed string, step bool, permissive bool, filter tape.Filter) (tape.Config, error) {
 	if step {
-		return tape.Config{Mode: tape.StepMode, Permissive: permissive}, nil
+		return tape.Config{Mode: tape.StepMode, Permissive: permissive, Filter: filter}, nil
 	}
 
 	normalized := strings.ToLower(strings.TrimSpace(speed))
 	switch normalized {
 	case "", "max":
-		return tape.Config{Mode: tape.MaxSpeedMode, Permissive: permissive}, nil
+		return tape.Config{Mode: tape.MaxSpeedMode, Permissive: permissive, Filter: filter}, nil
 	case "realtime", "real-time", "1x":
-		return tape.Config{Mode: tape.RealTimeMode, Speed: 1, Permissive: permissive}, nil
+		return tape.Config{Mode: tape.RealTimeMode, Speed: 1, Permissive: permissive, Filter: filter}, nil
 	default:
 		if !strings.HasSuffix(normalized, "x") {
 			return tape.Config{}, fmt.Errorf("config error: invalid speed %q", speed)
@@ -211,7 +256,7 @@ func configFromFlags(speed string, step bool, permissive bool) (tape.Config, err
 		if err != nil || value <= 0 {
 			return tape.Config{}, fmt.Errorf("config error: invalid speed %q", speed)
 		}
-		return tape.Config{Mode: tape.AcceleratedMode, Speed: value, Permissive: permissive}, nil
+		return tape.Config{Mode: tape.AcceleratedMode, Speed: value, Permissive: permissive, Filter: filter}, nil
 	}
 }
 
@@ -221,6 +266,7 @@ func printSummary(summary tape.Summary) {
 	fmt.Printf("First event:  %s\n", formatTimestamp(summary.FirstEventTime))
 	fmt.Printf("Last event:   %s\n", formatTimestamp(summary.LastEventTime))
 	fmt.Printf("Elapsed:      %s\n", summary.WallDuration.Round(time.Microsecond))
+	fmt.Printf("Handler time: %s\n", summary.HandlerDuration.Round(time.Microsecond))
 	fmt.Printf("Throughput:   %.0f events/sec\n", summary.Throughput)
 	fmt.Printf("Allocations:  %s\n", formatBytes(summary.AllocBytes))
 	fmt.Printf("Errors:       %d\n", summary.ErrorCount)
@@ -269,13 +315,13 @@ func printUsage() {
 	fmt.Println("Tape: deterministic market replay for Go")
 	fmt.Println()
 	fmt.Println("Usage:")
-	fmt.Println("  tape replay <path> [--speed max|realtime|100x] [--step]")
-	fmt.Println("  tape inspect <path> [--sample N]")
+	fmt.Println("  tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+	fmt.Println("  tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
 	fmt.Println("  tape bench [--events N] [--symbols N]")
-	fmt.Println("  tape check <path> [--runs N]")
+	fmt.Println("  tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
 }
 
-func sampleEvents(path string, limit int) ([]tape.Event, error) {
+func sampleEvents(path string, limit int, filter tape.Filter) ([]tape.Event, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -295,10 +341,67 @@ func sampleEvents(path string, limit int) ([]tape.Event, error) {
 			}
 			return nil, err
 		}
+		if !filter.Matches(event) {
+			continue
+		}
 		samples = append(samples, event)
 	}
 
 	return samples, nil
+}
+
+func filterFromFlags(symbols string, eventTypes string, from string, to string) (tape.Filter, error) {
+	startTime, err := parseFilterTime("from", from)
+	if err != nil {
+		return tape.Filter{}, err
+	}
+	endTime, err := parseFilterTime("to", to)
+	if err != nil {
+		return tape.Filter{}, err
+	}
+
+	return tape.Filter{
+		Symbols:    splitFilterValues(symbols),
+		EventTypes: splitFilterValues(eventTypes),
+		StartTime:  startTime,
+		EndTime:    endTime,
+	}, nil
+}
+
+func splitFilterValues(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		values = append(values, value)
+	}
+
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func parseFilterTime(name string, raw string) (time.Time, error) {
+	if strings.TrimSpace(raw) == "" {
+		return time.Time{}, nil
+	}
+
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("config error: invalid %s time %q", name, raw)
 }
 
 func formatBytes(total uint64) string {

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -33,6 +33,67 @@ func TestRunInspectShowsSampleEvents(t *testing.T) {
 	}
 }
 
+func TestRunInspectAppliesFiltersToSummaryAndSample(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mixed.tape")
+	records := strings.Join([]string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":93.12,"size":10,"seq":1},"index":0}`,
+		`{"type":"bar","payload":{"time":"2026-04-24T09:31:00Z","symbol":"ERICB","open":93.00,"high":93.50,"low":92.90,"close":93.40,"volume":100,"seq":2},"index":1}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:32:00Z","symbol":"VOLV","price":301.00,"size":5,"seq":3},"index":2}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:33:00Z","symbol":"ERICB","price":93.55,"size":8,"seq":4},"index":3}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(records), 0o600); err != nil {
+		t.Fatalf("write recording: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		err := run([]string{
+			"inspect",
+			path,
+			"--symbol", "ericb",
+			"--event-type", "tick",
+			"--from", "2026-04-24T09:32:30Z",
+			"--to", "2026-04-24T09:33:00Z",
+			"--sample", "2",
+		})
+		if err != nil {
+			t.Fatalf("run inspect: %v", err)
+		}
+	})
+
+	for _, fragment := range []string{
+		"Events:      1",
+		"Types:       tick=1",
+		"Symbols:     ERICB=1",
+		"Sample:",
+		"symbol=ERICB",
+		"price=",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output missing %q\n%s", fragment, output)
+		}
+	}
+	for _, fragment := range []string{"VOLV", "open="} {
+		if strings.Contains(output, fragment) {
+			t.Fatalf("output unexpectedly contains %q\n%s", fragment, output)
+		}
+	}
+}
+
+func TestRunInspectRejectsInvalidTimeRange(t *testing.T) {
+	err := run([]string{
+		"inspect",
+		filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+		"--from", "2026-04-24T10:00:00Z",
+		"--to", "2026-04-24T09:00:00Z",
+	})
+	if err == nil {
+		t.Fatal("run inspect error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "filter start time") {
+		t.Fatalf("error = %v, want filter time-range error", err)
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/src/config.go
+++ b/src/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Mode        Mode
 	Speed       float64
 	Permissive  bool
+	Filter      Filter
 	StepReader  io.Reader
 	StepWriter  io.Writer
 	EventCodecs []EventCodec
@@ -36,5 +37,10 @@ func (c Config) normalized() Config {
 	if c.StepWriter == nil {
 		c.StepWriter = os.Stdout
 	}
+	c.Filter = c.Filter.normalized()
 	return c
+}
+
+func (c Config) validate() error {
+	return c.Filter.validate()
 }

--- a/src/engine.go
+++ b/src/engine.go
@@ -39,17 +39,18 @@ func (c contextClock) Now() time.Time {
 }
 
 type Summary struct {
-	Events         int
-	ErrorCount     int
-	StartedAt      time.Time
-	FinishedAt     time.Time
-	WallDuration   time.Duration
-	Throughput     float64
-	AllocBytes     uint64
-	FirstEventTime time.Time
-	LastEventTime  time.Time
-	EventTypes     map[string]int
-	Symbols        map[string]int
+	Events          int
+	ErrorCount      int
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	WallDuration    time.Duration
+	HandlerDuration time.Duration
+	Throughput      float64
+	AllocBytes      uint64
+	FirstEventTime  time.Time
+	LastEventTime   time.Time
+	EventTypes      map[string]int
+	Symbols         map[string]int
 }
 
 type Engine struct {
@@ -91,6 +92,10 @@ func (e *Engine) OnBar(handler func(Context, Bar) error) {
 }
 
 func (e *Engine) RunFile(path string) (Summary, error) {
+	if err := e.config.validate(); err != nil {
+		return Summary{}, err
+	}
+
 	stream, err := OpenStreamWithCodecs(path, e.config.EventCodecs...)
 	if err != nil {
 		return Summary{}, err
@@ -101,6 +106,10 @@ func (e *Engine) RunFile(path string) (Summary, error) {
 }
 
 func (e *Engine) Run(stream Stream) (summary Summary, err error) {
+	if err := e.config.validate(); err != nil {
+		return Summary{}, err
+	}
+
 	summary = Summary{
 		StartedAt:  time.Now(),
 		EventTypes: map[string]int{},
@@ -110,7 +119,12 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 	runtime.ReadMemStats(&startMem)
 	defer finalizeSummary(&summary, startMem)
 
-	handler := e.chainHandlers()
+	timer := NewHandlerTimer()
+	defer func() {
+		summary.HandlerDuration = timer.Total()
+	}()
+
+	handler := e.chainHandlers(timer)
 	clock := newReplayClock(e.config)
 	var prev Event
 
@@ -129,6 +143,11 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 		if err = validateOrdering(prev, event, e.config.Permissive); err != nil {
 			summary.ErrorCount++
 			return summary, err
+		}
+		prev = event
+
+		if !e.config.Filter.Matches(event) {
+			continue
 		}
 
 		if err = clock.Wait(summary.Events, event.Timestamp()); err != nil {
@@ -156,7 +175,6 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 		}
 
 		summary.Events++
-		prev = event
 	}
 
 	return summary, nil
@@ -177,7 +195,7 @@ func finalizeSummary(summary *Summary, startMem runtime.MemStats) {
 	}
 }
 
-func (e *Engine) chainHandlers() EventHandler {
+func (e *Engine) chainHandlers(timer *HandlerTimer) EventHandler {
 	handler := func(ctx Context, event Event) error {
 		for _, registered := range e.handlers {
 			if err := registered(ctx, event); err != nil {
@@ -187,9 +205,11 @@ func (e *Engine) chainHandlers() EventHandler {
 		return nil
 	}
 
+	handler = timer.Middleware()(handler)
 	for index := len(e.middleware) - 1; index >= 0; index-- {
 		handler = e.middleware[index](handler)
 	}
+	handler = RecoverPanics()(handler)
 
 	return handler
 }

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -298,6 +299,128 @@ func TestSummaryTracksErrorsOnHandlerFailure(t *testing.T) {
 	}
 	if summary.FinishedAt.IsZero() {
 		t.Fatal("finished at is zero, want non-zero")
+	}
+}
+
+func TestSummaryRecoversFromHandlerPanic(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		panic("kaboom")
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+	))
+	if !errors.Is(err, tape.ErrHandlerPanic) {
+		t.Fatalf("err = %v, want %v", err, tape.ErrHandlerPanic)
+	}
+	if !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("err = %q, want panic value included", err.Error())
+	}
+	if summary.Events != 0 {
+		t.Fatalf("events = %d, want 0", summary.Events)
+	}
+	if summary.ErrorCount != 1 {
+		t.Fatalf("error count = %d, want 1", summary.ErrorCount)
+	}
+}
+
+func TestSummaryTracksHandlerDuration(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		time.Sleep(2 * time.Millisecond)
+		return nil
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 1, 0, time.UTC), Sym: "ERICB", Price: 93.20, Seq: 2},
+	))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.HandlerDuration < 4*time.Millisecond {
+		t.Fatalf("handler duration = %s, want at least 4ms", summary.HandlerDuration)
+	}
+	if summary.HandlerDuration > summary.WallDuration {
+		t.Fatalf("handler duration = %s, want <= wall duration %s", summary.HandlerDuration, summary.WallDuration)
+	}
+}
+
+func TestEngineAppliesSymbolTypeAndTimeFilters(t *testing.T) {
+	end := time.Date(2026, 4, 24, 9, 32, 0, 0, time.UTC)
+	engine := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		Filter: tape.Filter{
+			Symbols:    []string{"ericb"},
+			EventTypes: []string{"tick"},
+			StartTime:  time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC),
+			EndTime:    end,
+		},
+	})
+
+	var got []tape.Event
+	var indices []int
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		got = append(got, event)
+		indices = append(indices, ctx.Index)
+		return nil
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Bar{Time: time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC), Sym: "ERICB", Open: 93.10, High: 93.30, Low: 93.00, Close: 93.20, Seq: 2},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 31, 30, 0, time.UTC), Sym: "VOLV", Price: 301.00, Seq: 3},
+		tape.Tick{Time: end, Sym: "ERICB", Price: 93.25, Seq: 4},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 33, 0, 0, time.UTC), Sym: "ERICB", Price: 93.30, Seq: 5},
+	))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if summary.Events != 1 {
+		t.Fatalf("events = %d, want 1", summary.Events)
+	}
+	if summary.EventTypes["tick"] != 1 {
+		t.Fatalf("tick count = %d, want 1", summary.EventTypes["tick"])
+	}
+	if summary.Symbols["ERICB"] != 1 {
+		t.Fatalf("ERICB count = %d, want 1", summary.Symbols["ERICB"])
+	}
+	if !summary.FirstEventTime.Equal(end) {
+		t.Fatalf("first event = %s, want %s", summary.FirstEventTime, end)
+	}
+	if !summary.LastEventTime.Equal(end) {
+		t.Fatalf("last event = %s, want %s", summary.LastEventTime, end)
+	}
+	if len(got) != 1 {
+		t.Fatalf("handler events = %d, want 1", len(got))
+	}
+	if tick, ok := got[0].(tape.Tick); !ok || tick.Sym != "ERICB" || !tick.Time.Equal(end) {
+		t.Fatalf("handler event = %#v, want ERICB tick at %s", got[0], end)
+	}
+	if len(indices) != 1 || indices[0] != 0 {
+		t.Fatalf("indices = %v, want [0]", indices)
+	}
+}
+
+func TestEngineRejectsInvalidFilterTimeRange(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		Filter: tape.Filter{
+			StartTime: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 4, 24, 9, 0, 0, 0, time.UTC),
+		},
+	})
+
+	_, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+	))
+	if err == nil {
+		t.Fatal("run error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "filter start time") {
+		t.Fatalf("error = %v, want filter time-range error", err)
 	}
 }
 

--- a/src/errors.go
+++ b/src/errors.go
@@ -1,25 +1,6 @@
 package tape
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
 var ErrDeterminismMismatch = errors.New("determinism check failed")
 var ErrHandlerPanic = errors.New("handler panic")
-
-type PanicError struct {
-	Value any
-	Stack []byte
-}
-
-func (e *PanicError) Error() string {
-	if e == nil {
-		return ErrHandlerPanic.Error()
-	}
-	return fmt.Sprintf("%s: %v", ErrHandlerPanic, e.Value)
-}
-
-func (e *PanicError) Unwrap() error {
-	return ErrHandlerPanic
-}

--- a/src/filter.go
+++ b/src/filter.go
@@ -1,0 +1,93 @@
+package tape
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Filter struct {
+	Symbols    []string
+	EventTypes []string
+	StartTime  time.Time
+	EndTime    time.Time
+}
+
+func (f Filter) normalized() Filter {
+	f.Symbols = normalizeFilterValues(f.Symbols, normalizeSymbol)
+	f.EventTypes = normalizeFilterValues(f.EventTypes, normalizeEventType)
+	return f
+}
+
+func (f Filter) validate() error {
+	if !f.StartTime.IsZero() && !f.EndTime.IsZero() && f.StartTime.After(f.EndTime) {
+		return fmt.Errorf(
+			"config error: filter start time %s is after end time %s",
+			f.StartTime.Format(time.RFC3339Nano),
+			f.EndTime.Format(time.RFC3339Nano),
+		)
+	}
+	return nil
+}
+
+func (f Filter) Matches(event Event) bool {
+	if len(f.Symbols) > 0 && !containsNormalizedValue(f.Symbols, event.Symbol(), normalizeSymbol) {
+		return false
+	}
+	if len(f.EventTypes) > 0 && !containsNormalizedValue(f.EventTypes, event.Type(), normalizeEventType) {
+		return false
+	}
+
+	timestamp := event.Timestamp()
+	if !f.StartTime.IsZero() && timestamp.Before(f.StartTime) {
+		return false
+	}
+	if !f.EndTime.IsZero() && timestamp.After(f.EndTime) {
+		return false
+	}
+
+	return true
+}
+
+func normalizeFilterValues(values []string, normalize func(string) string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		candidate := normalize(value)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		normalized = append(normalized, candidate)
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func containsNormalizedValue(values []string, candidate string, normalize func(string) string) bool {
+	normalizedCandidate := normalize(candidate)
+	for _, value := range values {
+		if normalize(value) == normalizedCandidate {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSymbol(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+func normalizeEventType(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/src/middleware.go
+++ b/src/middleware.go
@@ -1,7 +1,7 @@
 package tape
 
 import (
-	"runtime/debug"
+	"fmt"
 	"time"
 )
 
@@ -10,10 +10,7 @@ func RecoverPanics() Middleware {
 		return func(ctx Context, event Event) (err error) {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					err = &PanicError{
-						Value: recovered,
-						Stack: debug.Stack(),
-					}
+					err = fmt.Errorf("%w: %v", ErrHandlerPanic, recovered)
 				}
 			}()
 
@@ -42,8 +39,5 @@ func (t *HandlerTimer) Middleware() Middleware {
 }
 
 func (t *HandlerTimer) Total() time.Duration {
-	if t == nil {
-		return 0
-	}
 	return t.total
 }


### PR DESCRIPTION
This PR adds reusable symbol, event-type, and inclusive time-range filters to Tape and exposes them through `replay`, `inspect`, and `check`.
It applies filtering inside the engine so summaries, sampling, recording, and determinism checks all operate on the same subset, and documents the new CLI usage.
It also adds handler-duration reporting plus simpler wrapped panic errors so replay summaries and failures are easier to reason about.
Validation: `go test ./...`.
