### PR TITLE
[codex] Add runnable replay examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ go install github.com/erik-kroon/tape/cmd/tape@latest
 tape replay testdata/bars_5_rows.csv --speed 100x --metrics
 ```
 
+Runnable example:
+
+```bash
+go run ./examples/replay
+```
+
 ## Replay a filtered subset
 
 ```bash
@@ -45,6 +51,12 @@ tape replay testdata/ticks_5_rows.csv --step
 tape replay testdata/ticks_5_rows.csv --record sessions/opening-bell.tape
 ```
 
+Runnable example:
+
+```bash
+go run ./examples/record_replay
+```
+
 ## Inspect a recording
 
 ```bash
@@ -61,6 +73,12 @@ tape check testdata/bars_5_rows.csv --runs 5
 
 ```bash
 tape bench --events 1000000 --symbols 100
+```
+
+Runnable example:
+
+```bash
+go run ./examples/benchmark
 ```
 
 ## Use as a library

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -94,6 +95,50 @@ func TestRunInspectRejectsInvalidTimeRange(t *testing.T) {
 	}
 }
 
+func TestRunnableExamples(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		path      string
+		fragments []string
+	}{
+		{
+			name: "replay",
+			path: "./examples/replay",
+			fragments: []string{
+				"09:30:00 ERICB close=92.70",
+				"Replayed 5 bar events across 1 symbol(s)",
+			},
+		},
+		{
+			name: "record_replay",
+			path: "./examples/record_replay",
+			fragments: []string{
+				"Recorded 5 tick events into opening-bell.tape",
+				"replay[0] ERICB price=92.50 size=100",
+				"Replayed 5 events from the recording",
+			},
+		},
+		{
+			name: "benchmark",
+			path: "./examples/benchmark",
+			fragments: []string{
+				"Benchmark events: 50000",
+				"Benchmark symbols: 8",
+				"Throughput:",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := runGoProgram(t, tc.path)
+			for _, fragment := range tc.fragments {
+				if !strings.Contains(output, fragment) {
+					t.Fatalf("output missing %q\n%s", fragment, output)
+				}
+			}
+		})
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
@@ -118,6 +163,18 @@ func captureStdout(t *testing.T, fn func()) string {
 	output, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatalf("read output: %v", err)
+	}
+	return string(output)
+}
+
+func runGoProgram(t *testing.T, path string) string {
+	t.Helper()
+
+	command := exec.Command("go", "run", path)
+	command.Dir = filepath.Join("..", "..")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run %s: %v\n%s", path, err, output)
 	}
 	return string(output)
 }

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	tape "github.com/erik-kroon/tape/src"
+)
+
+func main() {
+	result, err := tape.RunSyntheticBenchmark(tape.Config{Mode: tape.MaxSpeedMode}, 50000, 8, 42)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Benchmark events: %d\n", result.Events)
+	fmt.Printf("Benchmark symbols: %d\n", result.Symbols)
+	fmt.Printf("Elapsed: %s\n", result.Elapsed.Round(0))
+	fmt.Printf("Throughput: %.0f events/sec\n", result.Throughput)
+}

--- a/examples/record_replay/main.go
+++ b/examples/record_replay/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/erik-kroon/tape/internal/exampledata"
+	tape "github.com/erik-kroon/tape/src"
+)
+
+func main() {
+	recordingDir, err := os.MkdirTemp("", "tape-record-replay-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(recordingDir)
+
+	recordingPath := filepath.Join(recordingDir, "opening-bell.tape")
+	recorder, err := tape.NewRecorder(recordingPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	source := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	source.Use(recorder.Middleware())
+
+	recorded, err := source.RunFile(exampledata.Path("testdata", "ticks_5_rows.csv"))
+	closeErr := recorder.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if closeErr != nil {
+		log.Fatal(closeErr)
+	}
+
+	fmt.Printf("Recorded %d tick events into %s\n", recorded.Events, filepath.Base(recordingPath))
+
+	replay := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	replay.OnTick(func(ctx tape.Context, tick tape.Tick) error {
+		if ctx.Index < 2 {
+			fmt.Printf("replay[%d] %s price=%.2f size=%.0f\n", ctx.Index, tick.Symbol(), tick.Price, tick.Size)
+		}
+		return nil
+	})
+
+	replayed, err := replay.RunFile(recordingPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Replayed %d events from the recording\n", replayed.Events)
+}

--- a/examples/replay/main.go
+++ b/examples/replay/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/erik-kroon/tape/internal/exampledata"
+	tape "github.com/erik-kroon/tape/src"
+)
+
+func main() {
+	engine := tape.NewEngine(tape.Config{
+		Mode:  tape.AcceleratedMode,
+		Speed: 100,
+	})
+
+	engine.OnBar(func(ctx tape.Context, bar tape.Bar) error {
+		fmt.Printf("%s %s close=%.2f\n", ctx.Clock().Now().Format("15:04:05"), bar.Symbol(), bar.Close)
+		return nil
+	})
+
+	summary, err := engine.RunFile(exampledata.Path("testdata", "bars_5_rows.csv"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Replayed %d bar events across %d symbol(s)\n", summary.Events, len(summary.Symbols))
+}

--- a/internal/exampledata/exampledata.go
+++ b/internal/exampledata/exampledata.go
@@ -1,0 +1,18 @@
+package exampledata
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// Path resolves a path from the repository root so examples can be run from any directory.
+func Path(parts ...string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return filepath.Join(parts...)
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	segments := append([]string{repoRoot}, parts...)
+	return filepath.Join(segments...)
+}


### PR DESCRIPTION
## Summary

- add runnable Go examples for replay, record/replay, and benchmarking workflows
- add a small internal path helper so the examples can locate repo fixtures from any working directory
- document the example entrypoints in the README and exercise them from the CLI test suite

## Validation

- go run ./examples/replay
- go run ./examples/record_replay
- go run ./examples/benchmark
- go test ./...
