### PR TITLE
[codex] add replay output sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tape does not execute trades and does not provide financial advice.
 
 - A small Go library with `Tick` and `Bar` event types
 - A replay engine with max-speed, real-time, accelerated, and step modes
+- Output sinks for replayed events
 - CSV readers for tick and OHLCV bar data
 - JSONL session recording and replay through `.tape` files
 - A CLI with `replay`, `inspect`, `bench`, and `check`
@@ -80,6 +81,11 @@ func main() {
 		Mode:  tape.AcceleratedMode,
 		Speed: 100,
 	})
+
+	engine.AddSink(tape.OutputSinkFunc(func(ctx tape.Context, event tape.Event) error {
+		fmt.Println("sink", ctx.Index, event.Symbol())
+		return nil
+	}))
 
 	engine.OnBar(func(ctx tape.Context, bar tape.Bar) error {
 		fmt.Println(ctx.Clock().Now(), bar.Symbol(), bar.Close)

--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -83,10 +83,10 @@ func runReplay(args []string) error {
 
 	engine := tape.NewEngine(config)
 	if *printEvents || *step {
-		engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		engine.AddSink(tape.OutputSinkFunc(func(ctx tape.Context, event tape.Event) error {
 			fmt.Println(formatEvent(ctx.Index, event))
 			return nil
-		})
+		}))
 	}
 
 	var recorder *tape.Recorder
@@ -96,7 +96,7 @@ func runReplay(args []string) error {
 			return err
 		}
 		defer recorder.Close()
-		engine.Use(recorder.Middleware())
+		engine.AddSink(recorder)
 	}
 
 	summary, err := engine.RunFile(flags.Arg(0))

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -33,6 +33,56 @@ func TestRunInspectShowsSampleEvents(t *testing.T) {
 	}
 }
 
+func TestRunReplayPrintsEvents(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := run([]string{
+			"replay",
+			"--print",
+			"--metrics=false",
+			filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+		})
+		if err != nil {
+			t.Fatalf("run replay: %v", err)
+		}
+	})
+
+	for _, fragment := range []string{
+		"seq=1",
+		"seq=5",
+		"symbol=ERICB",
+		"price=",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output missing %q\n%s", fragment, output)
+		}
+	}
+}
+
+func TestRunReplayRecordsEvents(t *testing.T) {
+	recordPath := filepath.Join(t.TempDir(), "session.tape")
+
+	err := run([]string{
+		"replay",
+		"--metrics=false",
+		"--record", recordPath,
+		filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+	})
+	if err != nil {
+		t.Fatalf("run replay: %v", err)
+	}
+
+	contents, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("read recording: %v", err)
+	}
+	if count := strings.Count(string(contents), "\n"); count != 5 {
+		t.Fatalf("record lines = %d, want 5", count)
+	}
+	if !strings.Contains(string(contents), `"type":"tick"`) {
+		t.Fatalf("recording missing tick payloads\n%s", string(contents))
+	}
+}
+
 func TestRunInspectAppliesFiltersToSummaryAndSample(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mixed.tape")
 	records := strings.Join([]string{

--- a/src/engine.go
+++ b/src/engine.go
@@ -57,6 +57,7 @@ type Engine struct {
 	config     Config
 	handlers   []EventHandler
 	middleware []Middleware
+	sinks      []OutputSink
 }
 
 func NewEngine(config Config) *Engine {
@@ -65,6 +66,10 @@ func NewEngine(config Config) *Engine {
 
 func (e *Engine) Use(middleware Middleware) {
 	e.middleware = append(e.middleware, middleware)
+}
+
+func (e *Engine) AddSink(sink OutputSink) {
+	e.sinks = append(e.sinks, sink)
 }
 
 func (e *Engine) OnEvent(handler EventHandler) {
@@ -197,6 +202,11 @@ func finalizeSummary(summary *Summary, startMem runtime.MemStats) {
 
 func (e *Engine) chainHandlers(timer *HandlerTimer) EventHandler {
 	handler := func(ctx Context, event Event) error {
+		for _, sink := range e.sinks {
+			if err := sink.Write(ctx, event); err != nil {
+				return err
+			}
+		}
 		for _, registered := range e.handlers {
 			if err := registered(ctx, event); err != nil {
 				return err

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +52,7 @@ func TestRecorderRoundTrip(t *testing.T) {
 	}
 
 	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
-	engine.Use(recorder.Middleware())
+	engine.AddSink(recorder)
 	summary, err := engine.RunFile(filepath.Join("..", "testdata", "ticks_5_rows.csv"))
 	closeErr := recorder.Close()
 	if err != nil {
@@ -106,7 +107,7 @@ func TestRecorderRoundTripWithCustomCodec(t *testing.T) {
 	}
 
 	source := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
-	source.Use(recorder.Middleware())
+	source.AddSink(recorder)
 	summary, err := source.Run(newEventStream(
 		headlineEvent{
 			Time:     time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
@@ -269,6 +270,41 @@ func TestContextClockExposesReplayTime(t *testing.T) {
 		if !got[index].Equal(timestamps[index]) {
 			t.Fatalf("timestamp[%d] = %s, want %s", index, got[index], timestamps[index])
 		}
+	}
+}
+
+func TestOutputSinksReceiveReplayedEventsBeforeHandlers(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+
+	var calls []string
+	engine.AddSink(tape.OutputSinkFunc(func(ctx tape.Context, event tape.Event) error {
+		calls = append(calls, fmt.Sprintf("sink:%d:%s", ctx.Index, event.Symbol()))
+		return nil
+	}))
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		calls = append(calls, fmt.Sprintf("handler:%d:%s", ctx.Index, event.Symbol()))
+		return nil
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 1, 0, time.UTC), Sym: "VOLV", Price: 301.00, Seq: 2},
+	))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+
+	want := []string{
+		"sink:0:ERICB",
+		"handler:0:ERICB",
+		"sink:1:VOLV",
+		"handler:1:VOLV",
+	}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
 	}
 }
 

--- a/src/session_jsonl.go
+++ b/src/session_jsonl.go
@@ -42,12 +42,16 @@ func NewRecorderWithCodecs(path string, codecs ...EventCodec) (*Recorder, error)
 func (r *Recorder) Middleware() Middleware {
 	return func(next EventHandler) EventHandler {
 		return func(ctx Context, event Event) error {
-			if err := r.Record(ctx.Index, event); err != nil {
+			if err := r.Write(ctx, event); err != nil {
 				return err
 			}
 			return next(ctx, event)
 		}
 	}
+}
+
+func (r *Recorder) Write(ctx Context, event Event) error {
+	return r.Record(ctx.Index, event)
 }
 
 func (r *Recorder) Record(index int, event Event) error {

--- a/src/sink.go
+++ b/src/sink.go
@@ -1,0 +1,11 @@
+package tape
+
+type OutputSink interface {
+	Write(Context, Event) error
+}
+
+type OutputSinkFunc func(Context, Event) error
+
+func (f OutputSinkFunc) Write(ctx Context, event Event) error {
+	return f(ctx, event)
+}


### PR DESCRIPTION
This change adds first-class output sinks to the replay engine so replayed events can be routed to reusable destinations instead of forcing CLI printing and session recording through ad hoc event handlers or recorder-specific middleware.
The engine now supports `AddSink`, the recorder implements the sink interface, and `tape replay` uses sinks for both `--print` and `--record`, which keeps replay output concerns on one explicit extension path while preserving existing behavior.
The diff also updates engine and CLI tests to verify sink ordering, printed replay output, and recorded session output, and documents the new sink API in the README.
Validation was done with `go test ./...`.
