### PR TITLE
[codex] add start-at seek support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ tape replay testdata/bars_5_rows.csv --speed 100x --metrics
 tape replay testdata/bars_5_rows.csv --symbol ERICB --event-type bar --from 2026-04-24T09:31:00Z --to 2026-04-24T09:33:00Z
 ```
 
+## Seek to a starting position
+
+```bash
+tape replay testdata/ticks_5_rows.csv --start-at 2026-04-24T09:30:00.500Z
+tape inspect testdata/ticks_5_rows.csv --start-at 4 --sample 2
+```
+
 ## Step through a session
 
 ```bash
@@ -99,6 +106,8 @@ This repository is an MVP scaffold aligned to the PRD. It focuses on determinist
 Replay summaries report event totals, wall-clock elapsed time, throughput, allocation volume, and error counts. The inspect command prints a short event sample to make recorded sessions easier to sanity-check from the terminal.
 
 `replay`, `inspect`, and `check` all support the same inclusive filters: `--symbol` for one or more comma-separated symbols, `--event-type` for one or more comma-separated event types, and `--from` / `--to` for RFC3339 time bounds.
+
+Those commands also support `--start-at` to seek before replay begins. `--start-at` accepts an RFC3339 timestamp, a `YYYY-MM-DD` date, or a sequence number, and starts from the first event at or after that position.
 
 ## Custom event codecs
 

--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -56,6 +56,7 @@ func runReplay(args []string) error {
 	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
 	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
 	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
+	startAt := flags.String("start-at", "", "seek to the first event at or after an RFC3339 timestamp, date, or sequence")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
 		"--speed":      true,
@@ -64,19 +65,24 @@ func runReplay(args []string) error {
 		"--event-type": true,
 		"--from":       true,
 		"--to":         true,
+		"--start-at":   true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+		return errors.New("usage: tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 	}
 
 	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
 	if err != nil {
 		return err
 	}
+	position, err := startAtFromFlag(*startAt)
+	if err != nil {
+		return err
+	}
 
-	config, err := configFromFlags(*speed, *step, *permissive, filter)
+	config, err := configFromFlags(*speed, *step, *permissive, filter, position)
 	if err != nil {
 		return err
 	}
@@ -117,6 +123,7 @@ func runInspect(args []string) error {
 	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
 	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
 	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
+	startAt := flags.String("start-at", "", "seek to the first event at or after an RFC3339 timestamp, date, or sequence")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
 		"--sample":     true,
@@ -124,14 +131,19 @@ func runInspect(args []string) error {
 		"--event-type": true,
 		"--from":       true,
 		"--to":         true,
+		"--start-at":   true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+		return errors.New("usage: tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 	}
 
 	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
+	if err != nil {
+		return err
+	}
+	position, err := startAtFromFlag(*startAt)
 	if err != nil {
 		return err
 	}
@@ -141,13 +153,14 @@ func runInspect(args []string) error {
 		Mode:       tape.MaxSpeedMode,
 		Permissive: *permissive,
 		Filter:     filter,
+		StartAt:    position,
 	}
 	engine := tape.NewEngine(config)
 	summary, err := engine.RunFile(path)
 	if err != nil {
 		return err
 	}
-	samples, err := sampleEvents(path, *sample, filter)
+	samples, err := sampleEvents(path, *sample, config)
 	if err != nil {
 		return err
 	}
@@ -201,6 +214,7 @@ func runCheck(args []string) error {
 	eventTypes := flags.String("event-type", "", "comma-separated event-type filters")
 	from := flags.String("from", "", "inclusive replay start time (RFC3339)")
 	to := flags.String("to", "", "inclusive replay end time (RFC3339)")
+	startAt := flags.String("start-at", "", "seek to the first event at or after an RFC3339 timestamp, date, or sequence")
 	flags.SetOutput(os.Stderr)
 	if err := flags.Parse(reorderArgs(args, map[string]bool{
 		"--runs":       true,
@@ -208,14 +222,19 @@ func runCheck(args []string) error {
 		"--event-type": true,
 		"--from":       true,
 		"--to":         true,
+		"--start-at":   true,
 	})); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return errors.New("usage: tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+		return errors.New("usage: tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 	}
 
 	filter, err := filterFromFlags(*symbols, *eventTypes, *from, *to)
+	if err != nil {
+		return err
+	}
+	position, err := startAtFromFlag(*startAt)
 	if err != nil {
 		return err
 	}
@@ -224,6 +243,7 @@ func runCheck(args []string) error {
 		Mode:       tape.MaxSpeedMode,
 		Permissive: *permissive,
 		Filter:     filter,
+		StartAt:    position,
 	}, *runs)
 	if err != nil {
 		return err
@@ -237,17 +257,17 @@ func runCheck(args []string) error {
 	return nil
 }
 
-func configFromFlags(speed string, step bool, permissive bool, filter tape.Filter) (tape.Config, error) {
+func configFromFlags(speed string, step bool, permissive bool, filter tape.Filter, startAt tape.StartAt) (tape.Config, error) {
 	if step {
-		return tape.Config{Mode: tape.StepMode, Permissive: permissive, Filter: filter}, nil
+		return tape.Config{Mode: tape.StepMode, Permissive: permissive, Filter: filter, StartAt: startAt}, nil
 	}
 
 	normalized := strings.ToLower(strings.TrimSpace(speed))
 	switch normalized {
 	case "", "max":
-		return tape.Config{Mode: tape.MaxSpeedMode, Permissive: permissive, Filter: filter}, nil
+		return tape.Config{Mode: tape.MaxSpeedMode, Permissive: permissive, Filter: filter, StartAt: startAt}, nil
 	case "realtime", "real-time", "1x":
-		return tape.Config{Mode: tape.RealTimeMode, Speed: 1, Permissive: permissive, Filter: filter}, nil
+		return tape.Config{Mode: tape.RealTimeMode, Speed: 1, Permissive: permissive, Filter: filter, StartAt: startAt}, nil
 	default:
 		if !strings.HasSuffix(normalized, "x") {
 			return tape.Config{}, fmt.Errorf("config error: invalid speed %q", speed)
@@ -256,7 +276,7 @@ func configFromFlags(speed string, step bool, permissive bool, filter tape.Filte
 		if err != nil || value <= 0 {
 			return tape.Config{}, fmt.Errorf("config error: invalid speed %q", speed)
 		}
-		return tape.Config{Mode: tape.AcceleratedMode, Speed: value, Permissive: permissive, Filter: filter}, nil
+		return tape.Config{Mode: tape.AcceleratedMode, Speed: value, Permissive: permissive, Filter: filter, StartAt: startAt}, nil
 	}
 }
 
@@ -315,13 +335,13 @@ func printUsage() {
 	fmt.Println("Tape: deterministic market replay for Go")
 	fmt.Println()
 	fmt.Println("Usage:")
-	fmt.Println("  tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
-	fmt.Println("  tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+	fmt.Println("  tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
+	fmt.Println("  tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 	fmt.Println("  tape bench [--events N] [--symbols N]")
-	fmt.Println("  tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339]")
+	fmt.Println("  tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 }
 
-func sampleEvents(path string, limit int, filter tape.Filter) ([]tape.Event, error) {
+func sampleEvents(path string, limit int, config tape.Config) ([]tape.Event, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -333,6 +353,7 @@ func sampleEvents(path string, limit int, filter tape.Filter) ([]tape.Event, err
 	defer stream.Close()
 
 	samples := make([]tape.Event, 0, limit)
+	started := !config.StartAt.Active()
 	for len(samples) < limit {
 		event, err := stream.Next()
 		if err != nil {
@@ -341,7 +362,13 @@ func sampleEvents(path string, limit int, filter tape.Filter) ([]tape.Event, err
 			}
 			return nil, err
 		}
-		if !filter.Matches(event) {
+		if !started {
+			if !config.StartAt.Reached(event) {
+				continue
+			}
+			started = true
+		}
+		if !config.Filter.Matches(event) {
 			continue
 		}
 		samples = append(samples, event)
@@ -402,6 +429,30 @@ func parseFilterTime(name string, raw string) (time.Time, error) {
 	}
 
 	return time.Time{}, fmt.Errorf("config error: invalid %s time %q", name, raw)
+}
+
+func startAtFromFlag(raw string) (tape.StartAt, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return tape.StartAt{}, nil
+	}
+
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return tape.StartAt{Time: parsed}, nil
+		}
+	}
+
+	sequence, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		if sequence < 0 {
+			return tape.StartAt{}, fmt.Errorf("config error: start-at sequence must be non-negative")
+		}
+		return tape.StartAt{Sequence: sequence}, nil
+	}
+
+	return tape.StartAt{}, fmt.Errorf("config error: invalid start-at %q", raw)
 }
 
 func formatBytes(total uint64) string {

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -94,6 +94,75 @@ func TestRunInspectRejectsInvalidTimeRange(t *testing.T) {
 	}
 }
 
+func TestRunInspectStartAtTimestampSkipsEarlierEvents(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := run([]string{
+			"inspect",
+			filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+			"--start-at", "2026-04-24T09:30:00.500Z",
+			"--sample", "2",
+		})
+		if err != nil {
+			t.Fatalf("run inspect: %v", err)
+		}
+	})
+
+	for _, fragment := range []string{
+		"Events:      3",
+		"First event: 2026-04-24T09:30:00.5Z",
+		"seq=1 time=2026-04-24T09:30:00.5Z symbol=ERICB",
+		"seq=2 time=2026-04-24T09:30:00.75Z symbol=ERICB",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output missing %q\n%s", fragment, output)
+		}
+	}
+	if strings.Contains(output, "09:30:00.25Z") || strings.Contains(output, "price=92.5000") {
+		t.Fatalf("output unexpectedly contains events before start-at\n%s", output)
+	}
+}
+
+func TestRunInspectStartAtSequenceSkipsEarlierEvents(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := run([]string{
+			"inspect",
+			filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+			"--start-at", "4",
+			"--sample", "2",
+		})
+		if err != nil {
+			t.Fatalf("run inspect: %v", err)
+		}
+	})
+
+	for _, fragment := range []string{
+		"Events:      2",
+		"seq=1 time=2026-04-24T09:30:00.75Z symbol=ERICB",
+		"seq=2 time=2026-04-24T09:30:01Z symbol=ERICB",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output missing %q\n%s", fragment, output)
+		}
+	}
+	if strings.Contains(output, "09:30:00.5Z") {
+		t.Fatalf("output unexpectedly contains sequence before start-at\n%s", output)
+	}
+}
+
+func TestRunInspectRejectsInvalidStartAt(t *testing.T) {
+	err := run([]string{
+		"inspect",
+		filepath.Join("..", "..", "testdata", "ticks_5_rows.csv"),
+		"--start-at", "not-a-position",
+	})
+	if err == nil {
+		t.Fatal("run inspect error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "start-at") {
+		t.Fatalf("error = %v, want start-at error", err)
+	}
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/src/config.go
+++ b/src/config.go
@@ -1,8 +1,10 @@
 package tape
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type Mode string
@@ -19,6 +21,7 @@ type Config struct {
 	Speed       float64
 	Permissive  bool
 	Filter      Filter
+	StartAt     StartAt
 	StepReader  io.Reader
 	StepWriter  io.Writer
 	EventCodecs []EventCodec
@@ -42,5 +45,38 @@ func (c Config) normalized() Config {
 }
 
 func (c Config) validate() error {
+	if err := c.StartAt.validate(); err != nil {
+		return err
+	}
 	return c.Filter.validate()
+}
+
+type StartAt struct {
+	Time     time.Time
+	Sequence int64
+}
+
+func (s StartAt) Active() bool {
+	return !s.Time.IsZero() || s.Sequence > 0
+}
+
+func (s StartAt) validate() error {
+	if !s.Time.IsZero() && s.Sequence > 0 {
+		return fmt.Errorf("config error: start-at supports either time or sequence, not both")
+	}
+	if s.Sequence < 0 {
+		return fmt.Errorf("config error: start-at sequence must be non-negative")
+	}
+	return nil
+}
+
+func (s StartAt) Reached(event Event) bool {
+	switch {
+	case !s.Time.IsZero():
+		return !event.Timestamp().Before(s.Time)
+	case s.Sequence > 0:
+		return event.Sequence() >= s.Sequence
+	default:
+		return true
+	}
 }

--- a/src/engine.go
+++ b/src/engine.go
@@ -126,6 +126,7 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 
 	handler := e.chainHandlers(timer)
 	clock := newReplayClock(e.config)
+	started := !e.config.StartAt.Active()
 	var prev Event
 
 	for {
@@ -145,6 +146,13 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 			return summary, err
 		}
 		prev = event
+
+		if !started {
+			if !e.config.StartAt.Reached(event) {
+				continue
+			}
+			started = true
+		}
 
 		if !e.config.Filter.Matches(event) {
 			continue

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -424,6 +424,120 @@ func TestEngineRejectsInvalidFilterTimeRange(t *testing.T) {
 	}
 }
 
+func TestEngineStartsAtTimestampBeforeApplyingFilters(t *testing.T) {
+	startAt := time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC)
+	engine := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Time: startAt,
+		},
+		Filter: tape.Filter{
+			EventTypes: []string{"tick"},
+		},
+	})
+
+	var got []tape.Event
+	var indices []int
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		got = append(got, event)
+		indices = append(indices, ctx.Index)
+		return nil
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Bar{Time: startAt, Sym: "ERICB", Open: 93.10, High: 93.30, Low: 93.00, Close: 93.20, Seq: 2},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 31, 30, 0, time.UTC), Sym: "ERICB", Price: 93.25, Seq: 3},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 32, 0, 0, time.UTC), Sym: "VOLV", Price: 301.00, Seq: 4},
+	))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+	if len(got) != 2 {
+		t.Fatalf("handler events = %d, want 2", len(got))
+	}
+	if len(indices) != 2 || indices[0] != 0 || indices[1] != 1 {
+		t.Fatalf("indices = %v, want [0 1]", indices)
+	}
+
+	first, ok := got[0].(tape.Tick)
+	if !ok {
+		t.Fatalf("event[0] type = %T, want tape.Tick", got[0])
+	}
+	if first.Seq != 3 {
+		t.Fatalf("event[0] seq = %d, want 3", first.Seq)
+	}
+	if !summary.FirstEventTime.Equal(first.Time) {
+		t.Fatalf("first event time = %s, want %s", summary.FirstEventTime, first.Time)
+	}
+}
+
+func TestEngineStartsAtSequenceBeforeApplyingFilters(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Sequence: 3,
+		},
+		Filter: tape.Filter{
+			Symbols: []string{"ericb"},
+		},
+	})
+
+	var got []tape.Event
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		got = append(got, event)
+		return nil
+	})
+
+	summary, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 30, 0, time.UTC), Sym: "VOLV", Price: 301.00, Seq: 2},
+		tape.Bar{Time: time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC), Sym: "ERICB", Open: 93.10, High: 93.30, Low: 93.00, Close: 93.20, Seq: 3},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 31, 30, 0, time.UTC), Sym: "ERICB", Price: 93.25, Seq: 4},
+	))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+	if len(got) != 2 {
+		t.Fatalf("handler events = %d, want 2", len(got))
+	}
+	first, ok := got[0].(tape.Bar)
+	if !ok {
+		t.Fatalf("event[0] type = %T, want tape.Bar", got[0])
+	}
+	if first.Seq != 3 {
+		t.Fatalf("event[0] seq = %d, want 3", first.Seq)
+	}
+}
+
+func TestEngineRejectsInvalidStartAt(t *testing.T) {
+	engine := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Time:     time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC),
+			Sequence: 3,
+		},
+	})
+
+	_, err := engine.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+	))
+	if err == nil {
+		t.Fatal("run error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "start-at") {
+		t.Fatalf("error = %v, want start-at validation error", err)
+	}
+}
+
 type eventStream struct {
 	events []tape.Event
 	index  int


### PR DESCRIPTION
This adds `--start-at` support to `tape replay`, `tape inspect`, and `tape check`, accepting an RFC3339 timestamp, `YYYY-MM-DD` date, or sequence number and starting from the first event at or after that position. It also introduces a shared `StartAt` config in the engine so start-position seeking is applied consistently before normal filtering and replay, with inspect sampling updated to match runtime behavior. The change is covered with engine and CLI tests for timestamp and sequence seeks plus invalid input handling, and the README now documents the new usage. Checks: `go test ./...`.
