### PR TITLE
[codex] add tape session sidecar indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ go run ./examples/record_replay
 tape inspect sessions/opening-bell.tape --sample 5
 ```
 
+Tape recordings automatically write a `.idx` sidecar on close so `--start-at` can jump directly into large sessions. Existing recordings can be indexed or reindexed with:
+
+```bash
+tape index sessions/opening-bell.tape
+```
+
 ## Run a determinism check
 
 ```bash
@@ -132,6 +138,8 @@ Replay summaries report event totals, wall-clock elapsed time, throughput, alloc
 `replay`, `inspect`, and `check` all support the same inclusive filters: `--symbol` for one or more comma-separated symbols, `--event-type` for one or more comma-separated event types, and `--from` / `--to` for RFC3339 time bounds.
 
 Those commands also support `--start-at` to seek before replay begins. `--start-at` accepts an RFC3339 timestamp, a `YYYY-MM-DD` date, or a sequence number, and starts from the first event at or after that position.
+
+When a valid `.tape.idx` sidecar is present, Tape uses it automatically for `.tape` and `.jsonl` sessions. Missing or stale indexes fall back to the normal linear scan.
 
 ## Custom event codecs
 

--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -36,6 +36,8 @@ func run(args []string) error {
 		return runBench(args[1:])
 	case "check":
 		return runCheck(args[1:])
+	case "index":
+		return runIndex(args[1:])
 	case "help", "-h", "--help":
 		printUsage()
 		return nil
@@ -257,6 +259,24 @@ func runCheck(args []string) error {
 	return nil
 }
 
+func runIndex(args []string) error {
+	flags := flag.NewFlagSet("index", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	if err := flags.Parse(reorderArgs(args, map[string]bool{})); err != nil {
+		return err
+	}
+	if flags.NArg() != 1 {
+		return errors.New("usage: tape index <path>")
+	}
+
+	if err := tape.BuildSessionIndex(flags.Arg(0)); err != nil {
+		return err
+	}
+
+	fmt.Printf("Index written: %s\n", flags.Arg(0)+".idx")
+	return nil
+}
+
 func configFromFlags(speed string, step bool, permissive bool, filter tape.Filter, startAt tape.StartAt) (tape.Config, error) {
 	if step {
 		return tape.Config{Mode: tape.StepMode, Permissive: permissive, Filter: filter, StartAt: startAt}, nil
@@ -339,6 +359,7 @@ func printUsage() {
 	fmt.Println("  tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
 	fmt.Println("  tape bench [--events N] [--symbols N]")
 	fmt.Println("  tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]")
+	fmt.Println("  tape index <path>")
 }
 
 func sampleEvents(path string, limit int, config tape.Config) ([]tape.Event, error) {
@@ -354,6 +375,17 @@ func sampleEvents(path string, limit int, config tape.Config) ([]tape.Event, err
 
 	samples := make([]tape.Event, 0, limit)
 	started := !config.StartAt.Active()
+	if seeker, ok := stream.(interface {
+		SeekStartAt(tape.StartAt) (bool, error)
+	}); ok && config.StartAt.Active() {
+		seeked, err := seeker.SeekStartAt(config.StartAt)
+		if err != nil {
+			return nil, err
+		}
+		if seeked {
+			started = true
+		}
+	}
 	for len(samples) < limit {
 		event, err := stream.Next()
 		if err != nil {

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -84,6 +84,31 @@ func TestRunReplayRecordsEvents(t *testing.T) {
 	}
 }
 
+func TestRunIndexBuildsSidecar(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.tape")
+	records := strings.Join([]string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":93.12,"size":10,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:01Z","symbol":"ERICB","price":93.20,"size":8,"seq":2},"index":1}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(records), 0o600); err != nil {
+		t.Fatalf("write recording: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		err := run([]string{"index", path})
+		if err != nil {
+			t.Fatalf("run index: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Index written: "+path+".idx") {
+		t.Fatalf("output missing index path\n%s", output)
+	}
+	if _, err := os.Stat(path + ".idx"); err != nil {
+		t.Fatalf("stat index: %v", err)
+	}
+}
+
 func TestRunInspectAppliesFiltersToSummaryAndSample(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mixed.tape")
 	records := strings.Join([]string{

--- a/src/engine.go
+++ b/src/engine.go
@@ -132,6 +132,16 @@ func (e *Engine) Run(stream Stream) (summary Summary, err error) {
 	handler := e.chainHandlers(timer)
 	clock := newReplayClock(e.config)
 	started := !e.config.StartAt.Active()
+	if seeker, ok := stream.(startAtSeeker); ok && e.config.StartAt.Active() {
+		seeked, err := seeker.SeekStartAt(e.config.StartAt)
+		if err != nil {
+			summary.ErrorCount++
+			return summary, err
+		}
+		if seeked {
+			started = true
+		}
+	}
 	var prev Event
 
 	for {

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -78,6 +78,140 @@ func TestRecorderRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRecorderCloseWritesSessionIndex(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "session.tape")
+
+	recorder, err := tape.NewRecorder(recordingPath)
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+
+	if err := recorder.Record(0, tape.Tick{
+		Time:  time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+		Sym:   "ERICB",
+		Price: 93.12,
+		Seq:   1,
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+
+	if _, err := os.Stat(recordingPath + ".idx"); err != nil {
+		t.Fatalf("stat index: %v", err)
+	}
+}
+
+func TestRunFileSupportsStartAtWithoutSessionIndex(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "session.tape")
+
+	recorder, err := tape.NewRecorder(recordingPath)
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.AddSink(recorder)
+	if _, err := engine.RunFile(filepath.Join("..", "testdata", "ticks_5_rows.csv")); err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	if err := os.Remove(recordingPath + ".idx"); err != nil {
+		t.Fatalf("remove index: %v", err)
+	}
+
+	replay := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Sequence: 4,
+		},
+	})
+	summary, err := replay.RunFile(recordingPath)
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+}
+
+func TestRunFileSupportsStartAtWithValidSessionIndex(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "session.tape")
+
+	recorder, err := tape.NewRecorder(recordingPath)
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.AddSink(recorder)
+	if _, err := engine.RunFile(filepath.Join("..", "testdata", "ticks_5_rows.csv")); err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+
+	replay := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Sequence: 4,
+		},
+	})
+	summary, err := replay.RunFile(recordingPath)
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+}
+
+func TestRunFileFallsBackWhenSessionIndexIsStale(t *testing.T) {
+	recordingPath := filepath.Join(t.TempDir(), "session.tape")
+
+	recorder, err := tape.NewRecorder(recordingPath)
+	if err != nil {
+		t.Fatalf("new recorder: %v", err)
+	}
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	engine.AddSink(recorder)
+	if _, err := engine.RunFile(filepath.Join("..", "testdata", "ticks_5_rows.csv")); err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+
+	contents, err := os.ReadFile(recordingPath)
+	if err != nil {
+		t.Fatalf("read recording: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(contents)), "\n")
+	reduced := strings.Join(lines[:3], "\n") + "\n"
+	if err := os.WriteFile(recordingPath, []byte(reduced), 0o600); err != nil {
+		t.Fatalf("rewrite recording: %v", err)
+	}
+
+	replay := tape.NewEngine(tape.Config{
+		Mode: tape.MaxSpeedMode,
+		StartAt: tape.StartAt{
+			Sequence: 4,
+		},
+	})
+	summary, err := replay.RunFile(recordingPath)
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if summary.Events != 0 {
+		t.Fatalf("events = %d, want 0", summary.Events)
+	}
+}
+
 func TestCheckDeterminism(t *testing.T) {
 	result, err := tape.CheckDeterminism(filepath.Join("..", "testdata", "bars_5_rows.csv"), tape.Config{
 		Mode: tape.MaxSpeedMode,

--- a/src/session_index.go
+++ b/src/session_index.go
@@ -1,0 +1,203 @@
+package tape
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const sessionIndexVersion = 1
+
+type sessionIndex struct {
+	Version               int                 `json:"version"`
+	SourceSize            int64               `json:"source_size"`
+	SourceModTimeUnixNano int64               `json:"source_mod_time_unix_nano"`
+	Entries               []sessionIndexEntry `json:"entries"`
+}
+
+type sessionIndexEntry struct {
+	Offset   int64  `json:"offset"`
+	Time     string `json:"time"`
+	Sequence int64  `json:"sequence"`
+	Index    int    `json:"index"`
+}
+
+func BuildSessionIndex(path string) error {
+	return buildSessionIndexWithCodecs(path)
+}
+
+func buildSessionIndexWithCodecs(path string, codecs ...EventCodec) error {
+	if err := validateSessionIndexSource(path); err != nil {
+		return err
+	}
+
+	entries, err := scanSessionIndexEntries(path, codecs...)
+	if err != nil {
+		return err
+	}
+
+	return writeSessionIndex(path, entries)
+}
+
+func validateSessionIndexSource(path string) error {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".tape", ".jsonl":
+		return nil
+	default:
+		return fmt.Errorf("unsupported index source %q", ext)
+	}
+}
+
+func scanSessionIndexEntries(path string, codecs ...EventCodec) ([]sessionIndexEntry, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	registry, err := newEventCodecRegistry(codecs)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReader(file)
+	var (
+		offset  int64
+		entries []sessionIndexEntry
+	)
+	for {
+		lineOffset := offset
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			offset += int64(len(line))
+			record, err := decodeSessionRecord(line)
+			if err != nil {
+				return nil, err
+			}
+			event, err := registry.Decode(record)
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, newSessionIndexEntry(lineOffset, record.Index, event))
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+	}
+
+	return entries, nil
+}
+
+func writeSessionIndex(path string, entries []sessionIndexEntry) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	index := sessionIndex{
+		Version:               sessionIndexVersion,
+		SourceSize:            info.Size(),
+		SourceModTimeUnixNano: info.ModTime().UnixNano(),
+		Entries:               entries,
+	}
+
+	encoded, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+
+	indexPath := sessionIndexPath(path)
+	tempPath := indexPath + ".tmp"
+	if err := os.WriteFile(tempPath, encoded, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, indexPath)
+}
+
+func loadSessionIndex(path string) *sessionIndex {
+	data, err := os.ReadFile(sessionIndexPath(path))
+	if err != nil {
+		return nil
+	}
+
+	var index sessionIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil
+	}
+	if index.Version != sessionIndexVersion {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+	if info.Size() != index.SourceSize || info.ModTime().UnixNano() != index.SourceModTimeUnixNano {
+		return nil
+	}
+
+	return &index
+}
+
+func (i *sessionIndex) offsetFor(startAt StartAt) int64 {
+	if len(i.Entries) == 0 {
+		return i.SourceSize
+	}
+
+	if !startAt.Time.IsZero() {
+		target := startAt.Time
+		position := sort.Search(len(i.Entries), func(idx int) bool {
+			entryTime, err := time.Parse(time.RFC3339Nano, i.Entries[idx].Time)
+			if err != nil {
+				return true
+			}
+			return !entryTime.Before(target)
+		})
+		if position >= len(i.Entries) {
+			return i.SourceSize
+		}
+		return i.Entries[position].Offset
+	}
+
+	position := sort.Search(len(i.Entries), func(idx int) bool {
+		return i.Entries[idx].Sequence >= startAt.Sequence
+	})
+	if position >= len(i.Entries) {
+		return i.SourceSize
+	}
+	return i.Entries[position].Offset
+}
+
+func sessionIndexPath(path string) string {
+	return path + ".idx"
+}
+
+func decodeSessionRecord(line []byte) (sessionRecord, error) {
+	var record sessionRecord
+	if err := json.Unmarshal(line, &record); err != nil {
+		return sessionRecord{}, fmt.Errorf("decode error: invalid session record: %w", err)
+	}
+	return record, nil
+}
+
+func newSessionIndexEntry(offset int64, index int, event Event) sessionIndexEntry {
+	return sessionIndexEntry{
+		Offset:   offset,
+		Time:     event.Timestamp().UTC().Format(time.RFC3339Nano),
+		Sequence: event.Sequence(),
+		Index:    index,
+	}
+}

--- a/src/session_jsonl.go
+++ b/src/session_jsonl.go
@@ -2,18 +2,19 @@ package tape
 
 import (
 	"bufio"
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"sync"
 )
 
 type Recorder struct {
-	mu     sync.Mutex
-	file   *os.File
-	writer *bufio.Writer
-	codecs eventCodecRegistry
+	mu           sync.Mutex
+	path         string
+	file         *os.File
+	writer       *bufio.Writer
+	codecs       eventCodecRegistry
+	bytesWritten int64
+	indexEntries []sessionIndexEntry
 }
 
 func NewRecorder(path string) (*Recorder, error) {
@@ -33,6 +34,7 @@ func NewRecorderWithCodecs(path string, codecs ...EventCodec) (*Recorder, error)
 	}
 
 	return &Recorder{
+		path:   path,
 		file:   file,
 		writer: bufio.NewWriter(file),
 		codecs: registry,
@@ -62,12 +64,14 @@ func (r *Recorder) Record(index int, event Event) error {
 	if err != nil {
 		return err
 	}
+	r.indexEntries = append(r.indexEntries, newSessionIndexEntry(r.bytesWritten, index, event))
 	if _, err := r.writer.Write(record); err != nil {
 		return err
 	}
 	if err := r.writer.WriteByte('\n'); err != nil {
 		return err
 	}
+	r.bytesWritten += int64(len(record) + 1)
 	return r.writer.Flush()
 }
 
@@ -81,13 +85,17 @@ func (r *Recorder) Close() error {
 			return err
 		}
 	}
-	return r.file.Close()
+	if err := r.file.Close(); err != nil {
+		return err
+	}
+	return writeSessionIndex(r.path, r.indexEntries)
 }
 
 type jsonlStream struct {
 	file    *os.File
 	scanner *bufio.Scanner
 	codecs  eventCodecRegistry
+	index   *sessionIndex
 }
 
 func OpenJSONLStream(path string) (Stream, error) {
@@ -110,6 +118,7 @@ func OpenJSONLStreamWithCodecs(path string, codecs ...EventCodec) (Stream, error
 		file:    file,
 		scanner: bufio.NewScanner(file),
 		codecs:  registry,
+		index:   loadSessionIndex(path),
 	}, nil
 }
 
@@ -121,12 +130,23 @@ func (s *jsonlStream) Next() (Event, error) {
 		return nil, io.EOF
 	}
 
-	var record sessionRecord
-	if err := json.Unmarshal(s.scanner.Bytes(), &record); err != nil {
-		return nil, fmt.Errorf("decode error: invalid session record: %w", err)
+	record, err := decodeSessionRecord(s.scanner.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return s.codecs.Decode(record)
+}
+
+func (s *jsonlStream) SeekStartAt(startAt StartAt) (bool, error) {
+	if s.index == nil || !startAt.Active() {
+		return false, nil
 	}
 
-	return s.codecs.Decode(record)
+	if _, err := s.file.Seek(s.index.offsetFor(startAt), io.SeekStart); err != nil {
+		return false, err
+	}
+	s.scanner = bufio.NewScanner(s.file)
+	return true, nil
 }
 
 func (s *jsonlStream) Close() error {

--- a/src/stream.go
+++ b/src/stream.go
@@ -12,6 +12,10 @@ type Stream interface {
 	Close() error
 }
 
+type startAtSeeker interface {
+	SeekStartAt(StartAt) (bool, error)
+}
+
 func OpenStream(path string) (Stream, error) {
 	return OpenStreamWithCodecs(path)
 }


### PR DESCRIPTION
Adds `.tape.idx` sidecar indexes for recorded `.tape` and `.jsonl` sessions so `--start-at` can jump directly into larger recordings instead of always scanning from the beginning.
The recorder now writes indexes automatically on close, indexed streams use them transparently during replay and inspect sampling, and stale or missing indexes fall back safely to the existing linear scan behavior.
This also adds `tape index <path>` so existing recordings can be indexed or rebuilt explicitly from the CLI.
The change updates the README and expands engine and CLI coverage for valid, missing, stale, and manually built index paths.
Validation: `go test ./...`.
