### PR TITLE
[codex] Add golden replay test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Runnable example:
 go run ./examples/benchmark
 ```
 
+## Golden replay tests
+
+CLI output regressions are pinned with golden files in `cmd/tape/testdata`.
+
+Run the package tests normally:
+
+```bash
+go test ./cmd/tape
+```
+
+Refresh the golden files only when an output change is intentional:
+
+```bash
+UPDATE_GOLDEN=1 go test ./cmd/tape
+```
+
 ## Use as a library
 
 ```go

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/erik-kroon/tape/internal/testutil/golden"
 )
 
 func TestRunInspectShowsSampleEvents(t *testing.T) {
@@ -21,17 +23,7 @@ func TestRunInspectShowsSampleEvents(t *testing.T) {
 		}
 	})
 
-	for _, fragment := range []string{
-		"Events:      5",
-		"Sample:",
-		"seq=1",
-		"seq=2",
-		"price=",
-	} {
-		if !strings.Contains(output, fragment) {
-			t.Fatalf("output missing %q\n%s", fragment, output)
-		}
-	}
+	golden.Assert(t, filepath.Join("testdata", "inspect_sample_ticks_5_rows.golden"), output)
 }
 
 func TestRunReplayPrintsEvents(t *testing.T) {
@@ -47,16 +39,7 @@ func TestRunReplayPrintsEvents(t *testing.T) {
 		}
 	})
 
-	for _, fragment := range []string{
-		"seq=1",
-		"seq=5",
-		"symbol=ERICB",
-		"price=",
-	} {
-		if !strings.Contains(output, fragment) {
-			t.Fatalf("output missing %q\n%s", fragment, output)
-		}
-	}
+	golden.Assert(t, filepath.Join("testdata", "replay_print_ticks_5_rows.golden"), output)
 }
 
 func TestRunReplayRecordsEvents(t *testing.T) {

--- a/cmd/tape/testdata/inspect_sample_ticks_5_rows.golden
+++ b/cmd/tape/testdata/inspect_sample_ticks_5_rows.golden
@@ -1,0 +1,8 @@
+Events:      5
+First event: 2026-04-24T09:30:00Z
+Last event:  2026-04-24T09:30:01Z
+Types:       tick=5
+Symbols:     ERICB=5
+Sample:
+  seq=1 time=2026-04-24T09:30:00Z symbol=ERICB price=92.5000 size=100.0000
+  seq=2 time=2026-04-24T09:30:00.25Z symbol=ERICB price=92.5500 size=75.0000

--- a/cmd/tape/testdata/replay_print_ticks_5_rows.golden
+++ b/cmd/tape/testdata/replay_print_ticks_5_rows.golden
@@ -1,0 +1,5 @@
+seq=1 time=2026-04-24T09:30:00Z symbol=ERICB price=92.5000 size=100.0000
+seq=2 time=2026-04-24T09:30:00.25Z symbol=ERICB price=92.5500 size=75.0000
+seq=3 time=2026-04-24T09:30:00.5Z symbol=ERICB price=92.5300 size=80.0000
+seq=4 time=2026-04-24T09:30:00.75Z symbol=ERICB price=92.6000 size=60.0000
+seq=5 time=2026-04-24T09:30:01Z symbol=ERICB price=92.5800 size=90.0000

--- a/internal/testutil/golden/golden.go
+++ b/internal/testutil/golden/golden.go
@@ -1,0 +1,90 @@
+package golden
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const updateEnvVar = "UPDATE_GOLDEN"
+
+// Assert compares actual output against a golden file and can refresh it when requested.
+func Assert(t *testing.T, path string, actual string) {
+	t.Helper()
+
+	actual = normalize(actual)
+	if os.Getenv(updateEnvVar) == "1" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create golden dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(actual), 0o600); err != nil {
+			t.Fatalf("write golden file: %v", err)
+		}
+		return
+	}
+
+	expectedBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden file %s: %v", path, err)
+	}
+	expected := normalize(string(expectedBytes))
+	if expected == actual {
+		return
+	}
+
+	t.Fatalf(
+		"golden output mismatch for %s\n%s\nRefresh with `%s=1 go test ./cmd/tape`.",
+		path,
+		diff(expected, actual),
+		updateEnvVar,
+	)
+}
+
+func normalize(value string) string {
+	return strings.ReplaceAll(value, "\r\n", "\n")
+}
+
+func diff(expected string, actual string) string {
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(actual, "\n")
+
+	maxLines := max(len(expectedLines), len(actualLines))
+	var b strings.Builder
+	shown := 0
+
+	for index := 0; index < maxLines; index++ {
+		var want string
+		if index < len(expectedLines) {
+			want = expectedLines[index]
+		}
+
+		var got string
+		if index < len(actualLines) {
+			got = actualLines[index]
+		}
+
+		if want == got {
+			continue
+		}
+
+		fmt.Fprintf(&b, "line %d\n", index+1)
+		fmt.Fprintf(&b, "- want: %q\n", want)
+		fmt.Fprintf(&b, "+ got:  %q\n", got)
+		shown++
+		if shown == 8 {
+			remaining := maxLines - index - 1
+			if remaining > 0 {
+				fmt.Fprintf(&b, "... %d more differing line(s)\n", remaining)
+			}
+			break
+		}
+	}
+
+	if shown == 0 {
+		return "contents differ, but no differing lines were found"
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}


### PR DESCRIPTION
This adds reusable golden replay test helpers for developer-facing CLI output.
It converts the replay print and inspect sample tests to exact golden assertions, with fixtures under `cmd/tape/testdata` and line-level mismatch messages to make regressions obvious.
It also documents the intentional update flow with `UPDATE_GOLDEN=1 go test ./cmd/tape`.
Validation: `go test ./...`.
