### PR TITLE
[codex] Add strategy harness package

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,52 @@ func main() {
 
 Replay summaries include event totals, elapsed wall time, throughput, allocation volume, and error counts.
 
+## Strategy Harness
+
+For project-level strategy code, use the `strategy` package to bind user hooks to Tape without wiring `Engine` callbacks manually each time.
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/erik-kroon/tape/strategy"
+	tape "github.com/erik-kroon/tape/src"
+)
+
+func main() {
+	summary, err := strategy.RunFile("testdata/bars_5_rows.csv", tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			fmt.Println("starting", ctx.Path)
+			return nil
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar, ok := event.(tape.Bar)
+			if !ok {
+				return nil
+			}
+			fmt.Println(ctx.Index, bar.Symbol(), bar.Close)
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			fmt.Println("finished", result.Summary.Events, "events")
+			return nil
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("events:", summary.Events)
+}
+```
+
+Use `strategy.NewRunner` when you want to attach Tape middleware or sinks once and reuse the same harness across runs.
+
 ## Supported Parquet Schemas
 
 Tape currently supports flat Parquet files for two event families:

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -301,6 +301,16 @@ func TestRunnableExamples(t *testing.T) {
 				"Throughput:",
 			},
 		},
+		{
+			name: "strategy",
+			path: "./examples/strategy",
+			fragments: []string{
+				"Starting strategy on",
+				"bar[0] ERICB close=92.70",
+				"Strategy completed with 5 events",
+				"Harness summary events=5 symbols=1",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			output := runGoProgram(t, tc.path)

--- a/examples/strategy/main.go
+++ b/examples/strategy/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/erik-kroon/tape/internal/exampledata"
+	tape "github.com/erik-kroon/tape/src"
+	"github.com/erik-kroon/tape/strategy"
+)
+
+func main() {
+	summary, err := strategy.RunFile(exampledata.Path("testdata", "bars_5_rows.csv"), tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			fmt.Printf("Starting strategy on %s\n", ctx.Path)
+			return nil
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar, ok := event.(tape.Bar)
+			if !ok {
+				return nil
+			}
+			fmt.Printf("bar[%d] %s close=%.2f\n", ctx.Index, bar.Symbol(), bar.Close)
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			fmt.Printf("Strategy completed with %d events\n", result.Summary.Events)
+			return nil
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Harness summary events=%d symbols=%d\n", summary.Events, len(summary.Symbols))
+}

--- a/strategy/runner.go
+++ b/strategy/runner.go
@@ -1,0 +1,123 @@
+package strategy
+
+import (
+	"errors"
+
+	tape "github.com/erik-kroon/tape/src"
+)
+
+type RunContext struct {
+	Path string
+}
+
+type RunResult struct {
+	Path    string
+	Summary tape.Summary
+	Err     error
+}
+
+type Hooks struct {
+	OnStart func(RunContext) error
+	OnEvent func(tape.Context, tape.Event) error
+	OnEnd   func(RunResult) error
+}
+
+type Runner struct {
+	config     tape.Config
+	middleware []tape.Middleware
+	sinks      []tape.OutputSink
+}
+
+type Option func(*Runner)
+
+func NewRunner(config tape.Config, options ...Option) Runner {
+	runner := Runner{config: config}
+	for _, option := range options {
+		option(&runner)
+	}
+	return runner
+}
+
+func RunFile(path string, config tape.Config, hooks Hooks, options ...Option) (tape.Summary, error) {
+	return NewRunner(config, options...).RunFile(path, hooks)
+}
+
+func Run(stream tape.Stream, config tape.Config, hooks Hooks, options ...Option) (tape.Summary, error) {
+	return NewRunner(config, options...).Run(stream, hooks)
+}
+
+func WithMiddleware(middleware ...tape.Middleware) Option {
+	return func(runner *Runner) {
+		runner.middleware = append(runner.middleware, middleware...)
+	}
+}
+
+func WithSinks(sinks ...tape.OutputSink) Option {
+	return func(runner *Runner) {
+		runner.sinks = append(runner.sinks, sinks...)
+	}
+}
+
+func (r Runner) RunFile(path string, hooks Hooks) (tape.Summary, error) {
+	return r.run(RunContext{Path: path}, hooks, func(engine *tape.Engine) (tape.Summary, error) {
+		return engine.RunFile(path)
+	})
+}
+
+func (r Runner) Run(stream tape.Stream, hooks Hooks) (tape.Summary, error) {
+	return r.run(RunContext{}, hooks, func(engine *tape.Engine) (tape.Summary, error) {
+		return engine.Run(stream)
+	})
+}
+
+func (r Runner) run(runContext RunContext, hooks Hooks, execute func(*tape.Engine) (tape.Summary, error)) (summary tape.Summary, err error) {
+	if hooks.OnEvent == nil {
+		err = errors.New("strategy: OnEvent hook is required")
+		return summary, finalize(hooks.OnEnd, RunResult{
+			Path:    runContext.Path,
+			Summary: summary,
+			Err:     err,
+		})
+	}
+
+	defer func() {
+		err = finalize(hooks.OnEnd, RunResult{
+			Path:    runContext.Path,
+			Summary: summary,
+			Err:     err,
+		})
+	}()
+
+	if hooks.OnStart != nil {
+		if err = hooks.OnStart(runContext); err != nil {
+			return summary, err
+		}
+	}
+
+	engine := tape.NewEngine(r.config)
+	for _, middleware := range r.middleware {
+		engine.Use(middleware)
+	}
+	for _, sink := range r.sinks {
+		engine.AddSink(sink)
+	}
+	engine.OnEvent(hooks.OnEvent)
+
+	return execute(engine)
+}
+
+func finalize(onEnd func(RunResult) error, result RunResult) error {
+	if onEnd == nil {
+		return result.Err
+	}
+
+	endErr := onEnd(result)
+	if endErr == nil {
+		return result.Err
+	}
+	if result.Err == nil {
+		return endErr
+	}
+
+	return errors.Join(result.Err, endErr)
+}

--- a/strategy/runner_test.go
+++ b/strategy/runner_test.go
@@ -1,0 +1,216 @@
+package strategy_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	tape "github.com/erik-kroon/tape/src"
+	"github.com/erik-kroon/tape/strategy"
+)
+
+func TestRunFileInvokesHooksInOrder(t *testing.T) {
+	var calls []string
+	summary, err := strategy.RunFile(filepath.Join("..", "testdata", "bars_5_rows.csv"), tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			calls = append(calls, "start:"+filepath.Base(ctx.Path))
+			return nil
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			calls = append(calls, fmt.Sprintf("event:%d:%s", ctx.Index, event.Symbol()))
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			calls = append(calls, fmt.Sprintf("end:%d:%v", result.Summary.Events, result.Err == nil))
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+
+	want := []string{
+		"start:bars_5_rows.csv",
+		"event:0:ERICB",
+		"event:1:ERICB",
+		"event:2:ERICB",
+		"event:3:ERICB",
+		"event:4:ERICB",
+		"end:5:true",
+	}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	if summary.Events != 5 {
+		t.Fatalf("events = %d, want 5", summary.Events)
+	}
+}
+
+func TestRunCallsOnEndWhenStartFails(t *testing.T) {
+	wantErr := errors.New("start failed")
+	onEndCalls := 0
+
+	summary, err := strategy.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+	), tape.Config{Mode: tape.MaxSpeedMode}, strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			return wantErr
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			t.Fatal("OnEvent called, want no calls after start failure")
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			onEndCalls++
+			if !errors.Is(result.Err, wantErr) {
+				t.Fatalf("result err = %v, want %v", result.Err, wantErr)
+			}
+			if result.Summary.Events != 0 {
+				t.Fatalf("summary events = %d, want 0", result.Summary.Events)
+			}
+			return nil
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if summary.Events != 0 {
+		t.Fatalf("summary events = %d, want 0", summary.Events)
+	}
+	if onEndCalls != 1 {
+		t.Fatalf("OnEnd calls = %d, want 1", onEndCalls)
+	}
+}
+
+func TestRunCallsOnEndWhenRunFails(t *testing.T) {
+	wantErr := errors.New("handler failed")
+	onEndCalls := 0
+
+	summary, err := strategy.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 1, 0, time.UTC), Sym: "ERICB", Price: 93.20, Seq: 2},
+	), tape.Config{Mode: tape.MaxSpeedMode}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			if ctx.Index == 1 {
+				return wantErr
+			}
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			onEndCalls++
+			if !errors.Is(result.Err, wantErr) {
+				t.Fatalf("result err = %v, want %v", result.Err, wantErr)
+			}
+			if result.Summary.Events != 1 {
+				t.Fatalf("summary events = %d, want 1", result.Summary.Events)
+			}
+			return nil
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if summary.Events != 1 {
+		t.Fatalf("summary events = %d, want 1", summary.Events)
+	}
+	if onEndCalls != 1 {
+		t.Fatalf("OnEnd calls = %d, want 1", onEndCalls)
+	}
+}
+
+func TestRunnerOptionsApplyMiddlewareAndSinks(t *testing.T) {
+	var calls []string
+	runner := strategy.NewRunner(tape.Config{Mode: tape.MaxSpeedMode},
+		strategy.WithMiddleware(func(next tape.EventHandler) tape.EventHandler {
+			return func(ctx tape.Context, event tape.Event) error {
+				calls = append(calls, "middleware:before")
+				err := next(ctx, event)
+				calls = append(calls, "middleware:after")
+				return err
+			}
+		}),
+		strategy.WithSinks(tape.OutputSinkFunc(func(ctx tape.Context, event tape.Event) error {
+			calls = append(calls, "sink")
+			return nil
+		})),
+	)
+
+	summary, err := runner.Run(newEventStream(
+		tape.Tick{Time: time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC), Sym: "ERICB", Price: 93.12, Seq: 1},
+	), strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			calls = append(calls, "start")
+			return nil
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			calls = append(calls, "handler")
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			calls = append(calls, "end")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Events != 1 {
+		t.Fatalf("summary events = %d, want 1", summary.Events)
+	}
+
+	want := []string{"start", "middleware:before", "sink", "handler", "middleware:after", "end"}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestRunRejectsMissingOnEventHook(t *testing.T) {
+	onEndCalls := 0
+
+	_, err := strategy.Run(newEventStream(), tape.Config{Mode: tape.MaxSpeedMode}, strategy.Hooks{
+		OnEnd: func(result strategy.RunResult) error {
+			onEndCalls++
+			if result.Err == nil {
+				t.Fatal("result err = nil, want missing hook error")
+			}
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("err = nil, want missing hook error")
+	}
+	if err.Error() != "strategy: OnEvent hook is required" {
+		t.Fatalf("err = %q, want missing hook error", err.Error())
+	}
+	if onEndCalls != 1 {
+		t.Fatalf("OnEnd calls = %d, want 1", onEndCalls)
+	}
+}
+
+type eventStream struct {
+	events []tape.Event
+	index  int
+}
+
+func newEventStream(events ...tape.Event) *eventStream {
+	return &eventStream{events: events}
+}
+
+func (s *eventStream) Next() (tape.Event, error) {
+	if s.index >= len(s.events) {
+		return nil, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+
+func (s *eventStream) Close() error {
+	return nil
+}


### PR DESCRIPTION
Adds a new `strategy` package that runs Tape through explicit `OnStart`, `OnEvent`, and `OnEnd` hooks so strategy authors can target one stable seam instead of wiring the engine in each project.
It also introduces reusable runner options for shared middleware and sinks, plus a runnable example and README documentation for the new flow.
The change is covered by dedicated harness tests and by extending the runnable examples suite to include the strategy example.
Validation: `go test ./...`.
