### PR TITLE
[codex] Add strategy output snapshot assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,45 @@ func main() {
 
 Use `strategy.NewRunner` when you want to attach Tape middleware or sinks once and reuse the same harness across runs.
 
+For replay-and-verify tests, capture your strategy outputs and assert them against checked-in snapshots:
+
+```go
+type Signal struct {
+	Index  int       `json:"index"`
+	Time   time.Time `json:"time"`
+	Symbol string    `json:"symbol"`
+	Side   string    `json:"side"`
+}
+
+func TestSignals(t *testing.T) {
+	capture := strategy.NewOutputCapture[Signal]()
+
+	_, err := strategy.RunFile("testdata/bars_5_rows.csv", tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar, ok := event.(tape.Bar)
+			if !ok || bar.Close < 93.10 {
+				return nil
+			}
+			return capture.Record(Signal{
+				Index:  ctx.Index,
+				Time:   bar.Time,
+				Symbol: bar.Symbol(),
+				Side:   "buy",
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+
+	capture.AssertMatchesFile(t, "testdata/signals.jsonl")
+}
+```
+
+By default `OutputCapture` writes one JSON object per line, and `AssertMatchesFile` works with `.jsonl` or `.golden` snapshots. Use `WithOutputMarshal` when you want a custom single-line format for human-readable goldens, or `WriteFile` when you want to persist a fresh capture outside the test assertion path.
+
 ## Supported Parquet Schemas
 
 Tape currently supports flat Parquet files for two event families:
@@ -300,7 +339,7 @@ engine := tape.NewEngine(tape.Config{
 
 ## Development
 
-CLI output regressions are covered with golden files in `cmd/tape/testdata`.
+CLI output regressions are covered with golden files in `cmd/tape/testdata`, and strategy-level output regressions can be captured with `strategy.OutputCapture`.
 
 Run tests:
 
@@ -311,5 +350,5 @@ go test ./...
 Refresh golden files only when an output change is intentional:
 
 ```bash
-UPDATE_GOLDEN=1 go test ./cmd/tape
+UPDATE_GOLDEN=1 go test ./...
 ```

--- a/internal/testutil/golden/golden.go
+++ b/internal/testutil/golden/golden.go
@@ -11,7 +11,7 @@ import (
 const updateEnvVar = "UPDATE_GOLDEN"
 
 // Assert compares actual output against a golden file and can refresh it when requested.
-func Assert(t *testing.T, path string, actual string) {
+func Assert(t testing.TB, path string, actual string) {
 	t.Helper()
 
 	actual = normalize(actual)
@@ -35,7 +35,7 @@ func Assert(t *testing.T, path string, actual string) {
 	}
 
 	t.Fatalf(
-		"golden output mismatch for %s\n%s\nRefresh with `%s=1 go test ./cmd/tape`.",
+		"golden output mismatch for %s\n%s\nRefresh with `%s=1 go test ./...`.",
 		path,
 		diff(expected, actual),
 		updateEnvVar,

--- a/strategy/output_capture.go
+++ b/strategy/output_capture.go
@@ -1,0 +1,80 @@
+package strategy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erik-kroon/tape/internal/testutil/golden"
+)
+
+// OutputCapture records deterministic strategy outputs as single-line snapshots.
+type OutputCapture[T any] struct {
+	marshal func(T) ([]byte, error)
+	lines   []string
+}
+
+// OutputCaptureOption configures how an OutputCapture serializes values.
+type OutputCaptureOption[T any] func(*OutputCapture[T])
+
+// NewOutputCapture returns a line-oriented capture for deterministic strategy outputs.
+func NewOutputCapture[T any](options ...OutputCaptureOption[T]) *OutputCapture[T] {
+	capture := &OutputCapture[T]{
+		marshal: func(output T) ([]byte, error) {
+			return json.Marshal(output)
+		},
+	}
+
+	for _, option := range options {
+		option(capture)
+	}
+
+	return capture
+}
+
+// WithOutputMarshal overrides the default JSON encoder for captured outputs.
+func WithOutputMarshal[T any](marshal func(T) ([]byte, error)) OutputCaptureOption[T] {
+	return func(capture *OutputCapture[T]) {
+		capture.marshal = marshal
+	}
+}
+
+// Record appends one encoded output line to the capture.
+func (c *OutputCapture[T]) Record(output T) error {
+	encoded, err := c.marshal(output)
+	if err != nil {
+		return err
+	}
+	if bytes.ContainsAny(encoded, "\r\n") {
+		return fmt.Errorf("strategy: captured output must encode to a single line")
+	}
+
+	c.lines = append(c.lines, string(encoded))
+	return nil
+}
+
+// String renders the capture as newline-delimited output with a trailing newline.
+func (c *OutputCapture[T]) String() string {
+	if len(c.lines) == 0 {
+		return ""
+	}
+	return strings.Join(c.lines, "\n") + "\n"
+}
+
+// WriteFile persists the current capture to disk.
+func (c *OutputCapture[T]) WriteFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(c.String()), 0o600)
+}
+
+// AssertMatchesFile compares the capture against a checked-in snapshot file.
+func (c *OutputCapture[T]) AssertMatchesFile(t testing.TB, path string) {
+	t.Helper()
+	golden.Assert(t, path, c.String())
+}

--- a/strategy/output_capture_test.go
+++ b/strategy/output_capture_test.go
@@ -1,0 +1,129 @@
+package strategy_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tape "github.com/erik-kroon/tape/src"
+	"github.com/erik-kroon/tape/strategy"
+)
+
+type capturedSignal struct {
+	Index  int       `json:"index"`
+	Time   time.Time `json:"time"`
+	Symbol string    `json:"symbol"`
+	Side   string    `json:"side"`
+	Close  float64   `json:"close"`
+}
+
+func TestOutputCaptureMatchesJSONLFile(t *testing.T) {
+	capture := strategy.NewOutputCapture[capturedSignal]()
+
+	summary, err := strategy.RunFile(filepath.Join("..", "testdata", "bars_5_rows.csv"), tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar, ok := event.(tape.Bar)
+			if !ok || bar.Close < 93.10 {
+				return nil
+			}
+			return capture.Record(capturedSignal{
+				Index:  ctx.Index,
+				Time:   bar.Time,
+				Symbol: bar.Sym,
+				Side:   "buy",
+				Close:  bar.Close,
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if summary.Events != 5 {
+		t.Fatalf("events = %d, want 5", summary.Events)
+	}
+
+	capture.AssertMatchesFile(t, filepath.Join("testdata", "breakout_signals.jsonl"))
+}
+
+func TestOutputCaptureMatchesGoldenFileWithCustomFormatting(t *testing.T) {
+	capture := strategy.NewOutputCapture[capturedSignal](strategy.WithOutputMarshal(func(signal capturedSignal) ([]byte, error) {
+		return []byte(fmt.Sprintf(
+			"index=%d time=%s symbol=%s side=%s close=%.2f",
+			signal.Index,
+			signal.Time.Format(time.RFC3339),
+			signal.Symbol,
+			signal.Side,
+			signal.Close,
+		)), nil
+	}))
+
+	summary, err := strategy.RunFile(filepath.Join("..", "testdata", "bars_5_rows.csv"), tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar, ok := event.(tape.Bar)
+			if !ok || bar.Close < 93.10 {
+				return nil
+			}
+			return capture.Record(capturedSignal{
+				Index:  ctx.Index,
+				Time:   bar.Time,
+				Symbol: bar.Sym,
+				Side:   "buy",
+				Close:  bar.Close,
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("run file: %v", err)
+	}
+	if summary.Events != 5 {
+		t.Fatalf("events = %d, want 5", summary.Events)
+	}
+
+	capture.AssertMatchesFile(t, filepath.Join("testdata", "breakout_signals.golden"))
+}
+
+func TestOutputCaptureWriteFileWritesRecordedOutputs(t *testing.T) {
+	capture := strategy.NewOutputCapture[capturedSignal]()
+	if err := capture.Record(capturedSignal{
+		Index:  1,
+		Time:   time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC),
+		Symbol: "ERICB",
+		Side:   "buy",
+		Close:  93.00,
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "signals.jsonl")
+	if err := capture.WriteFile(path); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(contents) != capture.String() {
+		t.Fatalf("file contents = %q, want %q", string(contents), capture.String())
+	}
+}
+
+func TestOutputCaptureRejectsMultiLineEncodedOutput(t *testing.T) {
+	capture := strategy.NewOutputCapture[string](strategy.WithOutputMarshal(func(value string) ([]byte, error) {
+		return []byte(value), nil
+	}))
+
+	err := capture.Record("buy\nsell")
+	if err == nil {
+		t.Fatal("record error = nil, want multiline output error")
+	}
+	if err.Error() != "strategy: captured output must encode to a single line" {
+		t.Fatalf("record error = %q, want multiline output error", err.Error())
+	}
+}

--- a/strategy/testdata/breakout_signals.golden
+++ b/strategy/testdata/breakout_signals.golden
@@ -1,0 +1,2 @@
+index=2 time=2026-04-24T09:32:00Z symbol=ERICB side=buy close=93.15
+index=4 time=2026-04-24T09:34:00Z symbol=ERICB side=buy close=93.20

--- a/strategy/testdata/breakout_signals.jsonl
+++ b/strategy/testdata/breakout_signals.jsonl
@@ -1,0 +1,2 @@
+{"index":2,"time":"2026-04-24T09:32:00Z","symbol":"ERICB","side":"buy","close":93.15}
+{"index":4,"time":"2026-04-24T09:34:00Z","symbol":"ERICB","side":"buy","close":93.2}


### PR DESCRIPTION
## Summary
This changes Tape's strategy harness from pure replay to replay-and-verify by adding `strategy.OutputCapture`, a deterministic line-oriented snapshot helper that defaults to JSONL and supports custom single-line golden formatting. It also adds strategy fixtures and tests that verify snapshot matching, file writes, and multiline output rejection, so strategy code can assert emitted outputs instead of only asserting replay completion.

## Why
Before this change, Tape could replay inputs deterministically but shipped no built-in way for strategy tests to persist and compare structured outputs, which left the quant workflow incomplete. The shared golden helper now accepts `testing.TB` and points refresh guidance at `go test ./...`, so snapshot assertions work cleanly outside the CLI package as well.

## Validation
`go test ./...`
