### PR TITLE
[codex] Support merged replay across multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ tape replay testdata/bars_5_rows.csv \
   --to 2026-04-24T09:33:00Z
 ```
 
+Replay a merged stream from multiple files:
+
+```bash
+tape replay sessions/quotes.tape sessions/trades.tape --speed max --metrics
+```
+
 Step through events manually:
 
 ```bash
@@ -67,7 +73,7 @@ tape inspect testdata/ticks_5_rows.csv --start-at 4 --sample 2
 Replays events from a file through the engine.
 
 ```bash
-tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
+tape replay <path> [<path>...] [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
 ```
 
 Use `--record` to capture the replay into a `.tape` session:
@@ -88,7 +94,7 @@ go run ./examples/record_replay
 Prints a small sample of events from a source without replaying the full stream.
 
 ```bash
-tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
+tape inspect <path> [<path>...] [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
 ```
 
 Example:
@@ -102,7 +108,7 @@ tape inspect sessions/opening-bell.tape --sample 5
 Runs the same input multiple times and verifies deterministic output.
 
 ```bash
-tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
+tape check <path> [<path>...] [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]
 ```
 
 Examples:
@@ -143,7 +149,7 @@ tape index sessions/opening-bell.tape
 
 ## Filters and Start Positions
 
-`replay`, `inspect`, and `check` all support the same inclusive filters:
+`replay`, `inspect`, and `check` all support one or more input paths plus the same inclusive filters:
 
 - `--symbol` for one or more comma-separated symbols
 - `--event-type` for one or more comma-separated event types
@@ -194,6 +200,14 @@ func main() {
 	if _, err := engine.RunFile("testdata/bars_5_rows.csv"); err != nil {
 		log.Fatal(err)
 	}
+}
+```
+
+Use `RunFiles` to merge multiple ordered sources into one replay:
+
+```go
+if _, err := engine.RunFiles("sessions/quotes.tape", "sessions/trades.tape"); err != nil {
+	log.Fatal(err)
 }
 ```
 

--- a/cmd/tape/main.go
+++ b/cmd/tape/main.go
@@ -74,7 +74,7 @@ func runReplay(args []string) error {
 		engine.AddSink(recorder)
 	}
 
-	summary, err := engine.RunFile(options.path)
+	summary, err := engine.RunFiles(options.paths...)
 	if err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func runInspect(args []string) error {
 	}
 
 	engine := tape.NewEngine(config)
-	summary, err := engine.RunFile(options.path)
+	summary, err := engine.RunFiles(options.paths...)
 	if err != nil {
 		return err
 	}
-	samples, err := sampleEvents(options.path, options.sample, config)
+	samples, err := sampleEvents(options.paths, options.sample, config)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func runCheck(args []string) error {
 		return err
 	}
 
-	result, err := tape.CheckDeterminism(options.path, config, options.runs)
+	result, err := tape.CheckDeterminismFiles(options.paths, config, options.runs)
 	if err != nil {
 		return err
 	}
@@ -250,12 +250,12 @@ func printUsage() {
 	fmt.Println("  tape index <path>")
 }
 
-func sampleEvents(path string, limit int, config tape.Config) ([]tape.Event, error) {
+func sampleEvents(paths []string, limit int, config tape.Config) ([]tape.Event, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
 
-	selection, err := tape.OpenReplaySelection(path, config)
+	selection, err := tape.OpenReplaySelectionPaths(paths, config)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tape/main_test.go
+++ b/cmd/tape/main_test.go
@@ -90,6 +90,44 @@ func TestRunReplayRecordsEvents(t *testing.T) {
 	}
 }
 
+func TestRunReplayMergesMultipleSourcesInOrder(t *testing.T) {
+	quotesPath := filepath.Join(t.TempDir(), "quotes.tape")
+	tradesPath := filepath.Join(t.TempDir(), "trades.tape")
+	writeSessionFile(t, quotesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.50,"size":100,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:01Z","symbol":"ERICB","price":92.53,"size":80,"seq":3},"index":1}`,
+	})
+	writeSessionFile(t, tradesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.51,"size":10,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00.5Z","symbol":"ERICB","price":92.52,"size":12,"seq":2},"index":1}`,
+	})
+
+	output := captureStdout(t, func() {
+		err := run([]string{
+			"replay",
+			"--print",
+			"--metrics=false",
+			quotesPath,
+			tradesPath,
+		})
+		if err != nil {
+			t.Fatalf("run replay: %v", err)
+		}
+	})
+
+	want := []string{
+		"seq=1 time=2026-04-24T09:30:00Z symbol=ERICB price=92.5000 size=100.0000",
+		"seq=2 time=2026-04-24T09:30:00Z symbol=ERICB price=92.5100 size=10.0000",
+		"seq=3 time=2026-04-24T09:30:00.5Z symbol=ERICB price=92.5200 size=12.0000",
+		"seq=4 time=2026-04-24T09:30:01Z symbol=ERICB price=92.5300 size=80.0000",
+	}
+	for _, fragment := range want {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("output missing %q\n%s", fragment, output)
+		}
+	}
+}
+
 func TestRunIndexBuildsSidecar(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.tape")
 	records := strings.Join([]string{
@@ -361,4 +399,13 @@ func runGoProgram(t *testing.T, path string) string {
 		t.Fatalf("go run %s: %v\n%s", path, err, output)
 	}
 	return string(output)
+}
+
+func writeSessionFile(t *testing.T, path string, records []string) {
+	t.Helper()
+
+	data := strings.Join(records, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
 }

--- a/cmd/tape/replay_options.go
+++ b/cmd/tape/replay_options.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	replayUsageLine  = "tape replay <path> [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
-	inspectUsageLine = "tape inspect <path> [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
-	checkUsageLine   = "tape check <path> [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
+	replayUsageLine  = "tape replay <path> [<path>...] [--speed max|realtime|100x] [--step] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
+	inspectUsageLine = "tape inspect <path> [<path>...] [--sample N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
+	checkUsageLine   = "tape check <path> [<path>...] [--runs N] [--symbol SYM1,SYM2] [--event-type tick,bar] [--from RFC3339] [--to RFC3339] [--start-at RFC3339|YYYY-MM-DD|SEQ]"
 )
 
 type replayCommandSpec struct {
@@ -31,7 +31,7 @@ type replayCommandSpec struct {
 }
 
 type replayCommandOptions struct {
-	path       string
+	paths      []string
 	speed      string
 	step       bool
 	print      bool
@@ -83,11 +83,11 @@ func (o *replayCommandOptions) parse(spec replayCommandSpec, args []string) erro
 	if err := flags.Parse(reorderArgs(args, valueFlags)); err != nil {
 		return err
 	}
-	if flags.NArg() != 1 {
+	if flags.NArg() == 0 {
 		return errors.New("usage: " + spec.usage)
 	}
 
-	o.path = flags.Arg(0)
+	o.paths = append([]string(nil), flags.Args()...)
 	return nil
 }
 

--- a/cmd/tape/replay_options_test.go
+++ b/cmd/tape/replay_options_test.go
@@ -32,8 +32,8 @@ func TestReplayCommandOptionsParseAndBuildReplayConfig(t *testing.T) {
 		t.Fatalf("config: %v", err)
 	}
 
-	if options.path != "./session.tape" {
-		t.Fatalf("path = %q, want ./session.tape", options.path)
+	if got := strings.Join(options.paths, ","); got != "./session.tape" {
+		t.Fatalf("paths = %q, want ./session.tape", got)
 	}
 	if !options.step || !options.print || options.metrics || !options.permissive {
 		t.Fatalf("unexpected option flags: %+v", options)
@@ -79,6 +79,22 @@ func TestReplayCommandOptionsBuildInspectConfigDefaultsToMaxSpeed(t *testing.T) 
 	}
 	if options.sample != 2 {
 		t.Fatalf("sample = %d, want 2", options.sample)
+	}
+}
+
+func TestReplayCommandOptionsParseMultiplePaths(t *testing.T) {
+	options := newReplayCommandOptions()
+	err := options.parse(replaySpec, []string{
+		"./quotes.tape",
+		"./trades.tape",
+		"--metrics=false",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if got := strings.Join(options.paths, ","); got != "./quotes.tape,./trades.tape" {
+		t.Fatalf("paths = %q, want ./quotes.tape,./trades.tape", got)
 	}
 }
 

--- a/src/check.go
+++ b/src/check.go
@@ -58,6 +58,10 @@ type DeterminismResult struct {
 }
 
 func CheckDeterminism(path string, config Config, runs int) (DeterminismResult, error) {
+	return CheckDeterminismFiles([]string{path}, config, runs)
+}
+
+func CheckDeterminismFiles(paths []string, config Config, runs int) (DeterminismResult, error) {
 	if runs <= 0 {
 		runs = 1
 	}
@@ -73,7 +77,7 @@ func CheckDeterminism(path string, config Config, runs int) (DeterminismResult, 
 		}
 		engine.Use(hasher.Middleware())
 
-		summary, err := engine.RunFile(path)
+		summary, err := engine.RunFiles(paths...)
 		if err != nil {
 			return DeterminismResult{}, err
 		}

--- a/src/engine.go
+++ b/src/engine.go
@@ -97,11 +97,15 @@ func (e *Engine) OnBar(handler func(Context, Bar) error) {
 }
 
 func (e *Engine) RunFile(path string) (Summary, error) {
+	return e.RunFiles(path)
+}
+
+func (e *Engine) RunFiles(paths ...string) (Summary, error) {
 	if err := e.config.validate(); err != nil {
 		return Summary{}, err
 	}
 
-	selection, err := OpenReplaySelection(path, e.config)
+	selection, err := OpenReplaySelectionPaths(paths, e.config)
 	if err != nil {
 		return Summary{}, err
 	}

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -288,6 +288,72 @@ func TestCheckDeterminismParquet(t *testing.T) {
 	}
 }
 
+func TestRunFilesMergesSourcesInDeterministicOrder(t *testing.T) {
+	quotesPath := filepath.Join(t.TempDir(), "quotes.tape")
+	tradesPath := filepath.Join(t.TempDir(), "trades.tape")
+
+	writeSessionFile(t, quotesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.50,"size":100,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:01Z","symbol":"ERICB","price":92.53,"size":80,"seq":3},"index":1}`,
+	})
+	writeSessionFile(t, tradesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.51,"size":10,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00.5Z","symbol":"ERICB","price":92.52,"size":12,"seq":2},"index":1}`,
+	})
+
+	engine := tape.NewEngine(tape.Config{Mode: tape.MaxSpeedMode})
+	var got []string
+	engine.OnEvent(func(ctx tape.Context, event tape.Event) error {
+		got = append(got, fmt.Sprintf("%d:%s:%.2f", ctx.Index, event.Timestamp().Format(time.RFC3339Nano), event.(tape.Tick).Price))
+		return nil
+	})
+
+	summary, err := engine.RunFiles(quotesPath, tradesPath)
+	if err != nil {
+		t.Fatalf("run files: %v", err)
+	}
+	if summary.Events != 4 {
+		t.Fatalf("events = %d, want 4", summary.Events)
+	}
+
+	want := []string{
+		"0:2026-04-24T09:30:00Z:92.50",
+		"1:2026-04-24T09:30:00Z:92.51",
+		"2:2026-04-24T09:30:00.5Z:92.52",
+		"3:2026-04-24T09:30:01Z:92.53",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+}
+
+func TestCheckDeterminismFiles(t *testing.T) {
+	quotesPath := filepath.Join(t.TempDir(), "quotes.tape")
+	tradesPath := filepath.Join(t.TempDir(), "trades.tape")
+
+	writeSessionFile(t, quotesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.50,"size":100,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:01Z","symbol":"ERICB","price":92.53,"size":80,"seq":3},"index":1}`,
+	})
+	writeSessionFile(t, tradesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.51,"size":10,"seq":1},"index":0}`,
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00.5Z","symbol":"ERICB","price":92.52,"size":12,"seq":2},"index":1}`,
+	})
+
+	result, err := tape.CheckDeterminismFiles([]string{quotesPath, tradesPath}, tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, 3)
+	if err != nil {
+		t.Fatalf("check determinism files: %v", err)
+	}
+	if result.Events != 4 {
+		t.Fatalf("events = %d, want 4", result.Events)
+	}
+	if len(result.Hash) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(result.Hash))
+	}
+}
+
 func TestRecorderRoundTripWithCustomCodec(t *testing.T) {
 	recordingPath := filepath.Join(t.TempDir(), "custom-session.tape")
 	codec := headlineEventCodec()
@@ -526,6 +592,15 @@ func TestSummaryTracksErrorsOnHandlerFailure(t *testing.T) {
 	}
 	if summary.FinishedAt.IsZero() {
 		t.Fatal("finished at is zero, want non-zero")
+	}
+}
+
+func writeSessionFile(t *testing.T, path string, records []string) {
+	t.Helper()
+
+	data := strings.Join(records, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
 	}
 }
 

--- a/src/merge_stream.go
+++ b/src/merge_stream.go
@@ -1,0 +1,151 @@
+package tape
+
+import (
+	"container/heap"
+	"errors"
+	"io"
+)
+
+type mergedStream struct {
+	sources     []mergedStreamSource
+	queue       mergedStreamQueue
+	initialized bool
+}
+
+type mergedStreamSource struct {
+	stream Stream
+}
+
+type mergedStreamItem struct {
+	source int
+	event  Event
+}
+
+type mergedStreamQueue []mergedStreamItem
+
+func newMergedStream(streams []Stream) (*mergedStream, error) {
+	if len(streams) == 0 {
+		return nil, errors.New("open stream error: at least one input path is required")
+	}
+
+	sources := make([]mergedStreamSource, len(streams))
+	for index, stream := range streams {
+		sources[index] = mergedStreamSource{stream: stream}
+	}
+
+	return &mergedStream{sources: sources}, nil
+}
+
+func (s *mergedStream) Next() (Event, error) {
+	if err := s.initialize(); err != nil {
+		return nil, err
+	}
+	if len(s.queue) == 0 {
+		return nil, io.EOF
+	}
+
+	item := heap.Pop(&s.queue).(mergedStreamItem)
+	if err := s.enqueueNext(item.source); err != nil {
+		return nil, err
+	}
+	return item.event, nil
+}
+
+func (s *mergedStream) Close() error {
+	var err error
+	for _, source := range s.sources {
+		err = errors.Join(err, source.stream.Close())
+	}
+	return err
+}
+
+func (s *mergedStream) SeekStartAt(startAt StartAt) (bool, error) {
+	if s.initialized {
+		return false, nil
+	}
+
+	seekedAll := true
+	for _, source := range s.sources {
+		seeker, ok := source.stream.(startAtSeeker)
+		if !ok {
+			seekedAll = false
+			continue
+		}
+
+		seeked, err := seeker.SeekStartAt(startAt)
+		if err != nil {
+			return false, err
+		}
+		if !seeked {
+			seekedAll = false
+		}
+	}
+
+	return seekedAll, nil
+}
+
+func (s *mergedStream) initialize() error {
+	if s.initialized {
+		return nil
+	}
+	s.initialized = true
+
+	for index := range s.sources {
+		if err := s.enqueueNext(index); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *mergedStream) enqueueNext(sourceIndex int) error {
+	event, err := s.sources[sourceIndex].stream.Next()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	heap.Push(&s.queue, mergedStreamItem{
+		source: sourceIndex,
+		event:  event,
+	})
+	return nil
+}
+
+func (q mergedStreamQueue) Len() int {
+	return len(q)
+}
+
+func (q mergedStreamQueue) Less(i int, j int) bool {
+	left := q[i]
+	right := q[j]
+
+	if left.event.Timestamp().Before(right.event.Timestamp()) {
+		return true
+	}
+	if right.event.Timestamp().Before(left.event.Timestamp()) {
+		return false
+	}
+	if left.event.Sequence() != right.event.Sequence() {
+		return left.event.Sequence() < right.event.Sequence()
+	}
+	return left.source < right.source
+}
+
+func (q mergedStreamQueue) Swap(i int, j int) {
+	q[i], q[j] = q[j], q[i]
+}
+
+func (q *mergedStreamQueue) Push(value any) {
+	*q = append(*q, value.(mergedStreamItem))
+}
+
+func (q *mergedStreamQueue) Pop() any {
+	old := *q
+	last := len(old) - 1
+	item := old[last]
+	*q = old[:last]
+	return item
+}

--- a/src/replay_selection.go
+++ b/src/replay_selection.go
@@ -14,12 +14,16 @@ type ReplaySelection struct {
 }
 
 func OpenReplaySelection(path string, config Config) (*ReplaySelection, error) {
+	return OpenReplaySelectionPaths([]string{path}, config)
+}
+
+func OpenReplaySelectionPaths(paths []string, config Config) (*ReplaySelection, error) {
 	normalized := config.normalized()
 	if err := normalized.validate(); err != nil {
 		return nil, err
 	}
 
-	stream, err := OpenStreamWithCodecs(path, normalized.EventCodecs...)
+	stream, err := OpenStreamsWithCodecs(paths, normalized.EventCodecs...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/stream.go
+++ b/src/stream.go
@@ -1,6 +1,7 @@
 package tape
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -20,6 +21,10 @@ func OpenStream(path string) (Stream, error) {
 	return OpenStreamWithCodecs(path)
 }
 
+func OpenStreams(paths []string) (Stream, error) {
+	return OpenStreamsWithCodecs(paths)
+}
+
 func OpenStreamWithCodecs(path string, codecs ...EventCodec) (Stream, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 
@@ -33,6 +38,29 @@ func OpenStreamWithCodecs(path string, codecs ...EventCodec) (Stream, error) {
 	default:
 		return nil, fmt.Errorf("unsupported input format %q", ext)
 	}
+}
+
+func OpenStreamsWithCodecs(paths []string, codecs ...EventCodec) (Stream, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("open stream error: at least one input path is required")
+	}
+	if len(paths) == 1 {
+		return OpenStreamWithCodecs(paths[0], codecs...)
+	}
+
+	streams := make([]Stream, 0, len(paths))
+	for _, path := range paths {
+		stream, err := OpenStreamWithCodecs(path, codecs...)
+		if err != nil {
+			for _, opened := range streams {
+				_ = opened.Close()
+			}
+			return nil, err
+		}
+		streams = append(streams, stream)
+	}
+
+	return newMergedStream(streams)
 }
 
 type sliceStream struct {

--- a/strategy/runner.go
+++ b/strategy/runner.go
@@ -7,11 +7,13 @@ import (
 )
 
 type RunContext struct {
-	Path string
+	Path  string
+	Paths []string
 }
 
 type RunResult struct {
 	Path    string
+	Paths   []string
 	Summary tape.Summary
 	Err     error
 }
@@ -39,7 +41,11 @@ func NewRunner(config tape.Config, options ...Option) Runner {
 }
 
 func RunFile(path string, config tape.Config, hooks Hooks, options ...Option) (tape.Summary, error) {
-	return NewRunner(config, options...).RunFile(path, hooks)
+	return RunFiles([]string{path}, config, hooks, options...)
+}
+
+func RunFiles(paths []string, config tape.Config, hooks Hooks, options ...Option) (tape.Summary, error) {
+	return NewRunner(config, options...).RunFiles(paths, hooks)
 }
 
 func Run(stream tape.Stream, config tape.Config, hooks Hooks, options ...Option) (tape.Summary, error) {
@@ -59,8 +65,13 @@ func WithSinks(sinks ...tape.OutputSink) Option {
 }
 
 func (r Runner) RunFile(path string, hooks Hooks) (tape.Summary, error) {
-	return r.run(RunContext{Path: path}, hooks, func(engine *tape.Engine) (tape.Summary, error) {
-		return engine.RunFile(path)
+	return r.RunFiles([]string{path}, hooks)
+}
+
+func (r Runner) RunFiles(paths []string, hooks Hooks) (tape.Summary, error) {
+	runContext := newRunContext(paths)
+	return r.run(runContext, hooks, func(engine *tape.Engine) (tape.Summary, error) {
+		return engine.RunFiles(paths...)
 	})
 }
 
@@ -70,22 +81,32 @@ func (r Runner) Run(stream tape.Stream, hooks Hooks) (tape.Summary, error) {
 	})
 }
 
+func newRunContext(paths []string) RunContext {
+	cloned := append([]string(nil), paths...)
+	context := RunContext{Paths: cloned}
+	if len(cloned) == 1 {
+		context.Path = cloned[0]
+	}
+	return context
+}
+
+func newRunResult(runContext RunContext, summary tape.Summary, err error) RunResult {
+	return RunResult{
+		Path:    runContext.Path,
+		Paths:   append([]string(nil), runContext.Paths...),
+		Summary: summary,
+		Err:     err,
+	}
+}
+
 func (r Runner) run(runContext RunContext, hooks Hooks, execute func(*tape.Engine) (tape.Summary, error)) (summary tape.Summary, err error) {
 	if hooks.OnEvent == nil {
 		err = errors.New("strategy: OnEvent hook is required")
-		return summary, finalize(hooks.OnEnd, RunResult{
-			Path:    runContext.Path,
-			Summary: summary,
-			Err:     err,
-		})
+		return summary, finalize(hooks.OnEnd, newRunResult(runContext, summary, err))
 	}
 
 	defer func() {
-		err = finalize(hooks.OnEnd, RunResult{
-			Path:    runContext.Path,
-			Summary: summary,
-			Err:     err,
-		})
+		err = finalize(hooks.OnEnd, newRunResult(runContext, summary, err))
 	}()
 
 	if hooks.OnStart != nil {

--- a/strategy/runner_test.go
+++ b/strategy/runner_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +51,50 @@ func TestRunFileInvokesHooksInOrder(t *testing.T) {
 	}
 	if summary.Events != 5 {
 		t.Fatalf("events = %d, want 5", summary.Events)
+	}
+}
+
+func TestRunFilesExposeMergedPaths(t *testing.T) {
+	quotesPath := filepath.Join(t.TempDir(), "quotes.tape")
+	tradesPath := filepath.Join(t.TempDir(), "trades.tape")
+	writeSessionFile(t, quotesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00Z","symbol":"ERICB","price":92.50,"size":100,"seq":1},"index":0}`,
+	})
+	writeSessionFile(t, tradesPath, []string{
+		`{"type":"tick","payload":{"time":"2026-04-24T09:30:00.5Z","symbol":"ERICB","price":92.52,"size":12,"seq":2},"index":0}`,
+	})
+
+	var started strategy.RunContext
+	var ended strategy.RunResult
+	summary, err := strategy.RunFiles([]string{quotesPath, tradesPath}, tape.Config{
+		Mode: tape.MaxSpeedMode,
+	}, strategy.Hooks{
+		OnStart: func(ctx strategy.RunContext) error {
+			started = ctx
+			return nil
+		},
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			return nil
+		},
+		OnEnd: func(result strategy.RunResult) error {
+			ended = result
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("run files: %v", err)
+	}
+	if summary.Events != 2 {
+		t.Fatalf("events = %d, want 2", summary.Events)
+	}
+	if started.Path != "" {
+		t.Fatalf("start path = %q, want empty for multi-source run", started.Path)
+	}
+	if got := strings.Join(started.Paths, ","); got != quotesPath+","+tradesPath {
+		t.Fatalf("start paths = %q, want %q", got, quotesPath+","+tradesPath)
+	}
+	if got := strings.Join(ended.Paths, ","); got != quotesPath+","+tradesPath {
+		t.Fatalf("end paths = %q, want %q", got, quotesPath+","+tradesPath)
 	}
 }
 
@@ -213,4 +259,13 @@ func (s *eventStream) Next() (tape.Event, error) {
 
 func (s *eventStream) Close() error {
 	return nil
+}
+
+func writeSessionFile(t *testing.T, path string, records []string) {
+	t.Helper()
+
+	data := strings.Join(records, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
 }


### PR DESCRIPTION
This PR adds merged replay support so `replay`, `inspect`, and `check` can consume multiple ordered files or sessions, which is needed for realistic strategy tests that combine quotes, trades, or split symbol data.

Before this change the CLI and engine assumed exactly one source path, so users had to pre-concatenate data externally and lost a first-class deterministic replay path for multi-file inputs.

The fix introduces a heap-based merged stream with deterministic tie-breaking by timestamp, sequence, and input-path order, threads multi-path APIs through the engine and strategy runner (`RunFiles`, `CheckDeterminismFiles`, multi-path replay selection), and updates the CLI parsing plus README examples to document the new workflow.

Validation covers `go test ./...` and new unit tests for merged ordering, determinism across multiple files, CLI parsing and printing, and strategy hook path propagation.
