### PR TITLE
[codex] Add warmup and measured replay ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ type Signal struct {
 
 func TestSignals(t *testing.T) {
 	capture := strategy.NewOutputCapture[Signal]()
+	warmupStart := time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC)
+	measuredStart := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	measuredEnd := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
 
 	_, err := strategy.RunFile("testdata/bars_5_rows.csv", tape.Config{
 		Mode: tape.MaxSpeedMode,
@@ -280,14 +283,23 @@ func TestSignals(t *testing.T) {
 			if !ok || bar.Close < 93.10 {
 				return nil
 			}
-			return capture.Record(Signal{
-				Index:  ctx.Index,
+			return capture.RecordMeasured(ctx, Signal{
+				Index:  ctx.MeasuredIndex,
 				Time:   bar.Time,
 				Symbol: bar.Symbol(),
 				Side:   "buy",
 			})
 		},
-	})
+	}, strategy.WithReplayRanges(strategy.ReplayRanges{
+		Warmup: strategy.ReplayRange{
+			Start: warmupStart,
+			End:   measuredStart,
+		},
+		Measured: strategy.ReplayRange{
+			Start: measuredStart,
+			End:   measuredEnd,
+		},
+	}))
 	if err != nil {
 		t.Fatalf("run file: %v", err)
 	}
@@ -296,7 +308,7 @@ func TestSignals(t *testing.T) {
 }
 ```
 
-By default `OutputCapture` writes one JSON object per line, and `AssertMatchesFile` works with `.jsonl` or `.golden` snapshots. Use `WithOutputMarshal` when you want a custom single-line format for human-readable goldens, or `WriteFile` when you want to persist a fresh capture outside the test assertion path.
+`strategy.WithReplayRanges` expands the replay filter to cover both windows, while `ctx.Measured` and `ctx.MeasuredIndex` let your handler distinguish assertion events from warmup events. By default `OutputCapture` writes one JSON object per line, and `AssertMatchesFile` works with `.jsonl` or `.golden` snapshots. Use `RecordMeasured` when snapshots should ignore warmup output, `WithOutputMarshal` when you want a custom single-line format for human-readable goldens, or `WriteFile` when you want to persist a fresh capture outside the test assertion path.
 
 ## Supported Parquet Schemas
 

--- a/src/engine.go
+++ b/src/engine.go
@@ -14,9 +14,11 @@ type Clock interface {
 }
 
 type Context struct {
-	Index      int
-	StartedAt  time.Time
-	replayTime time.Time
+	Index         int
+	Measured      bool
+	MeasuredIndex int
+	StartedAt     time.Time
+	replayTime    time.Time
 }
 
 type EventHandler func(Context, Event) error
@@ -178,9 +180,11 @@ func (e *Engine) runSelection(selection *ReplaySelection) (summary Summary, err 
 		}
 
 		ctx := Context{
-			Index:      selected.Index,
-			StartedAt:  summary.StartedAt,
-			replayTime: event.Timestamp(),
+			Index:         selected.Index,
+			Measured:      true,
+			MeasuredIndex: selected.Index,
+			StartedAt:     summary.StartedAt,
+			replayTime:    event.Timestamp(),
 		}
 		if err = handler(ctx, event); err != nil {
 			summary.ErrorCount++

--- a/src/engine_test.go
+++ b/src/engine_test.go
@@ -509,6 +509,12 @@ func TestContextClockExposesReplayTime(t *testing.T) {
 		if replayTime := ctx.ReplayTime(); !replayTime.Equal(event.Timestamp()) {
 			t.Fatalf("replay time = %s, want %s", replayTime, event.Timestamp())
 		}
+		if !ctx.Measured {
+			t.Fatal("ctx.Measured = false, want true by default")
+		}
+		if ctx.MeasuredIndex != ctx.Index {
+			t.Fatalf("measured index = %d, want %d", ctx.MeasuredIndex, ctx.Index)
+		}
 		return nil
 	})
 

--- a/strategy/output_capture.go
+++ b/strategy/output_capture.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/erik-kroon/tape/internal/testutil/golden"
+	tape "github.com/erik-kroon/tape/src"
 )
 
 // OutputCapture records deterministic strategy outputs as single-line snapshots.
@@ -55,6 +56,14 @@ func (c *OutputCapture[T]) Record(output T) error {
 
 	c.lines = append(c.lines, string(encoded))
 	return nil
+}
+
+// RecordMeasured appends one encoded output line only for measured events.
+func (c *OutputCapture[T]) RecordMeasured(ctx tape.Context, output T) error {
+	if !ctx.Measured {
+		return nil
+	}
+	return c.Record(output)
 }
 
 // String renders the capture as newline-delimited output with a trailing newline.

--- a/strategy/output_capture_test.go
+++ b/strategy/output_capture_test.go
@@ -127,3 +127,50 @@ func TestOutputCaptureRejectsMultiLineEncodedOutput(t *testing.T) {
 		t.Fatalf("record error = %q, want multiline output error", err.Error())
 	}
 }
+
+func TestOutputCaptureRecordMeasuredSkipsWarmupOutputs(t *testing.T) {
+	capture := strategy.NewOutputCapture[capturedSignal]()
+	timestamps := []time.Time{
+		time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 32, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 33, 0, 0, time.UTC),
+	}
+
+	_, err := strategy.Run(newEventStream(
+		tape.Bar{Time: timestamps[0], Sym: "ERICB", Open: 93.00, High: 93.10, Low: 92.90, Close: 93.05, Seq: 1},
+		tape.Bar{Time: timestamps[1], Sym: "ERICB", Open: 93.05, High: 93.20, Low: 93.00, Close: 93.15, Seq: 2},
+		tape.Bar{Time: timestamps[2], Sym: "ERICB", Open: 93.15, High: 93.30, Low: 93.10, Close: 93.25, Seq: 3},
+		tape.Bar{Time: timestamps[3], Sym: "ERICB", Open: 93.25, High: 93.40, Low: 93.20, Close: 93.35, Seq: 4},
+	), tape.Config{Mode: tape.MaxSpeedMode}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			bar := event.(tape.Bar)
+			return capture.RecordMeasured(ctx, capturedSignal{
+				Index:  ctx.MeasuredIndex,
+				Time:   bar.Time,
+				Symbol: bar.Sym,
+				Side:   "buy",
+				Close:  bar.Close,
+			})
+		},
+	}, strategy.WithReplayRanges(strategy.ReplayRanges{
+		Warmup: strategy.ReplayRange{
+			Start: timestamps[0],
+			End:   timestamps[1],
+		},
+		Measured: strategy.ReplayRange{
+			Start: timestamps[2],
+			End:   timestamps[3],
+		},
+	}))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want := "" +
+		"{\"index\":0,\"time\":\"2026-04-24T09:32:00Z\",\"symbol\":\"ERICB\",\"side\":\"buy\",\"close\":93.25}\n" +
+		"{\"index\":1,\"time\":\"2026-04-24T09:33:00Z\",\"symbol\":\"ERICB\",\"side\":\"buy\",\"close\":93.35}\n"
+	if capture.String() != want {
+		t.Fatalf("capture = %q, want %q", capture.String(), want)
+	}
+}

--- a/strategy/replay_ranges.go
+++ b/strategy/replay_ranges.go
@@ -1,0 +1,132 @@
+package strategy
+
+import (
+	"fmt"
+	"time"
+
+	tape "github.com/erik-kroon/tape/src"
+)
+
+// ReplayRange defines an inclusive replay window.
+type ReplayRange struct {
+	Start time.Time
+	End   time.Time
+}
+
+func (r ReplayRange) Active() bool {
+	return !r.Start.IsZero() || !r.End.IsZero()
+}
+
+func (r ReplayRange) Contains(timestamp time.Time) bool {
+	if !r.Start.IsZero() && timestamp.Before(r.Start) {
+		return false
+	}
+	if !r.End.IsZero() && timestamp.After(r.End) {
+		return false
+	}
+	return true
+}
+
+func (r ReplayRange) validate(name string) error {
+	if !r.Start.IsZero() && !r.End.IsZero() && r.Start.After(r.End) {
+		return fmt.Errorf(
+			"strategy: %s start time %s is after end time %s",
+			name,
+			r.Start.Format(time.RFC3339Nano),
+			r.End.Format(time.RFC3339Nano),
+		)
+	}
+	return nil
+}
+
+// ReplayRanges separates indicator warmup from the measured assertion window.
+type ReplayRanges struct {
+	Warmup   ReplayRange
+	Measured ReplayRange
+}
+
+func (r ReplayRanges) Active() bool {
+	return r.Warmup.Active() || r.Measured.Active()
+}
+
+func (r ReplayRanges) validate() error {
+	if err := r.Warmup.validate("warmup range"); err != nil {
+		return err
+	}
+	if err := r.Measured.validate("measured range"); err != nil {
+		return err
+	}
+	if r.Warmup.Active() && !r.Measured.Active() {
+		return fmt.Errorf("strategy: measured range is required when warmup range is set")
+	}
+	if !r.Warmup.Start.IsZero() && !r.Measured.Start.IsZero() && r.Warmup.Start.After(r.Measured.Start) {
+		return fmt.Errorf("strategy: warmup range start time must be before or equal to measured range start time")
+	}
+	return nil
+}
+
+func (r ReplayRanges) combinedFilter(filter tape.Filter) (tape.Filter, error) {
+	if err := r.validate(); err != nil {
+		return filter, err
+	}
+	if !r.Active() {
+		return filter, nil
+	}
+	if !filter.StartTime.IsZero() || !filter.EndTime.IsZero() {
+		return filter, fmt.Errorf("strategy: replay ranges cannot be combined with config filter start/end time")
+	}
+
+	start, ok := earliestTime(r.Warmup.Start, r.Measured.Start)
+	if ok {
+		filter.StartTime = start
+	}
+	end, ok := latestTime(r.Warmup.End, r.Measured.End)
+	if ok {
+		filter.EndTime = end
+	}
+	return filter, nil
+}
+
+func (r ReplayRanges) decorateContext(ctx tape.Context, event tape.Event, measuredIndex *int) tape.Context {
+	if !r.Measured.Active() {
+		ctx.Measured = true
+		ctx.MeasuredIndex = ctx.Index
+		return ctx
+	}
+	if r.Measured.Contains(event.Timestamp()) {
+		ctx.Measured = true
+		ctx.MeasuredIndex = *measuredIndex
+		*measuredIndex = *measuredIndex + 1
+		return ctx
+	}
+
+	ctx.Measured = false
+	ctx.MeasuredIndex = -1
+	return ctx
+}
+
+func earliestTime(left time.Time, right time.Time) (time.Time, bool) {
+	switch {
+	case left.IsZero():
+		return right, !right.IsZero()
+	case right.IsZero():
+		return left, true
+	case left.Before(right):
+		return left, true
+	default:
+		return right, true
+	}
+}
+
+func latestTime(left time.Time, right time.Time) (time.Time, bool) {
+	switch {
+	case left.IsZero():
+		return right, !right.IsZero()
+	case right.IsZero():
+		return left, true
+	case left.After(right):
+		return left, true
+	default:
+		return right, true
+	}
+}

--- a/strategy/runner.go
+++ b/strategy/runner.go
@@ -26,6 +26,7 @@ type Hooks struct {
 
 type Runner struct {
 	config     tape.Config
+	ranges     ReplayRanges
 	middleware []tape.Middleware
 	sinks      []tape.OutputSink
 }
@@ -61,6 +62,12 @@ func WithMiddleware(middleware ...tape.Middleware) Option {
 func WithSinks(sinks ...tape.OutputSink) Option {
 	return func(runner *Runner) {
 		runner.sinks = append(runner.sinks, sinks...)
+	}
+}
+
+func WithReplayRanges(ranges ReplayRanges) Option {
+	return func(runner *Runner) {
+		runner.ranges = ranges
 	}
 }
 
@@ -105,6 +112,11 @@ func (r Runner) run(runContext RunContext, hooks Hooks, execute func(*tape.Engin
 		return summary, finalize(hooks.OnEnd, newRunResult(runContext, summary, err))
 	}
 
+	config, err := r.runtimeConfig()
+	if err != nil {
+		return summary, finalize(hooks.OnEnd, newRunResult(runContext, summary, err))
+	}
+
 	defer func() {
 		err = finalize(hooks.OnEnd, newRunResult(runContext, summary, err))
 	}()
@@ -115,16 +127,33 @@ func (r Runner) run(runContext RunContext, hooks Hooks, execute func(*tape.Engin
 		}
 	}
 
-	engine := tape.NewEngine(r.config)
+	engine := tape.NewEngine(config)
 	for _, middleware := range r.middleware {
 		engine.Use(middleware)
 	}
 	for _, sink := range r.sinks {
 		engine.AddSink(sink)
 	}
-	engine.OnEvent(hooks.OnEvent)
+	engine.OnEvent(r.wrapOnEvent(hooks.OnEvent))
 
 	return execute(engine)
+}
+
+func (r Runner) runtimeConfig() (tape.Config, error) {
+	config := r.config
+	filter, err := r.ranges.combinedFilter(config.Filter)
+	if err != nil {
+		return tape.Config{}, err
+	}
+	config.Filter = filter
+	return config, nil
+}
+
+func (r Runner) wrapOnEvent(onEvent func(tape.Context, tape.Event) error) func(tape.Context, tape.Event) error {
+	measuredIndex := 0
+	return func(ctx tape.Context, event tape.Event) error {
+		return onEvent(r.ranges.decorateContext(ctx, event, &measuredIndex), event)
+	}
 }
 
 func finalize(onEnd func(RunResult) error, result RunResult) error {

--- a/strategy/runner_test.go
+++ b/strategy/runner_test.go
@@ -216,6 +216,82 @@ func TestRunnerOptionsApplyMiddlewareAndSinks(t *testing.T) {
 	}
 }
 
+func TestRunAppliesWarmupAndMeasuredRanges(t *testing.T) {
+	timestamps := []time.Time{
+		time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 31, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 32, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 33, 0, 0, time.UTC),
+		time.Date(2026, 4, 24, 9, 34, 0, 0, time.UTC),
+	}
+
+	var got []string
+	summary, err := strategy.Run(newEventStream(
+		tape.Tick{Time: timestamps[0], Sym: "ERICB", Price: 93.10, Seq: 1},
+		tape.Tick{Time: timestamps[1], Sym: "ERICB", Price: 93.20, Seq: 2},
+		tape.Tick{Time: timestamps[2], Sym: "ERICB", Price: 93.30, Seq: 3},
+		tape.Tick{Time: timestamps[3], Sym: "ERICB", Price: 93.40, Seq: 4},
+		tape.Tick{Time: timestamps[4], Sym: "ERICB", Price: 93.50, Seq: 5},
+	), tape.Config{Mode: tape.MaxSpeedMode}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			got = append(got, fmt.Sprintf("%d:%t:%d:%d", ctx.Index, ctx.Measured, ctx.MeasuredIndex, event.Sequence()))
+			return nil
+		},
+	}, strategy.WithReplayRanges(strategy.ReplayRanges{
+		Warmup: strategy.ReplayRange{
+			Start: timestamps[0],
+			End:   timestamps[1],
+		},
+		Measured: strategy.ReplayRange{
+			Start: timestamps[2],
+			End:   timestamps[3],
+		},
+	}))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want := []string{
+		"0:false:-1:1",
+		"1:false:-1:2",
+		"2:true:0:3",
+		"3:true:1:4",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	if summary.Events != 4 {
+		t.Fatalf("summary events = %d, want 4", summary.Events)
+	}
+}
+
+func TestRunRejectsReplayRangesWhenConfigTimeFilterIsSet(t *testing.T) {
+	timestamp := time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC)
+
+	_, err := strategy.Run(newEventStream(
+		tape.Tick{Time: timestamp, Sym: "ERICB", Price: 93.10, Seq: 1},
+	), tape.Config{
+		Mode: tape.MaxSpeedMode,
+		Filter: tape.Filter{
+			StartTime: timestamp,
+		},
+	}, strategy.Hooks{
+		OnEvent: func(ctx tape.Context, event tape.Event) error {
+			return nil
+		},
+	}, strategy.WithReplayRanges(strategy.ReplayRanges{
+		Measured: strategy.ReplayRange{
+			Start: timestamp,
+		},
+	}))
+	if err == nil {
+		t.Fatal("err = nil, want replay-range conflict error")
+	}
+	if err.Error() != "strategy: replay ranges cannot be combined with config filter start/end time" {
+		t.Fatalf("err = %q, want replay-range conflict error", err.Error())
+	}
+}
+
 func TestRunRejectsMissingOnEventHook(t *testing.T) {
 	onEndCalls := 0
 


### PR DESCRIPTION
This adds strategy replay ranges so callers can replay a warmup window separately from the measured assertion window, with measured state exposed through `tape.Context` and `strategy.OutputCapture` helpers.
Previously the strategy harness only had a single replay filter, which forced indicator warmup and assertion ranges to be coupled even when tests only wanted to assert on the later slice.
The change also validates conflicting range/filter combinations and updates the README and tests to cover the new API and default measured behavior.
Validation: `go test ./...`.
